### PR TITLE
Improve Flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,4 +5,5 @@
 __tests__/flow
 
 [options]
+include_warnings=true
 suppress_comment= \\(.\\|\n\\)*\\$ExpectError

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "jest --watch",
     "test": "jest",
     "test:perf": "NODE_ENV=production yarn-or-npm build && cd __performance_tests__ && babel-node add-data.js && babel-node todo.js && babel-node incremental.js",
-    "test:flow": "yarn-or-npm flow check",
+    "test:flow": "yarn-or-npm flow check --max-warnings=0",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "build": "rimraf dist/ && cross-env NODE_ENV=production rollup -c && cpx \"src/immer.{d.ts,js.flow}\" dist",
     "prettier": "prettier \"*/**/*.js\" \"*/**/*.ts\" --ignore-path ./.prettierignore --write",

--- a/src/immer.js.flow
+++ b/src/immer.js.flow
@@ -22,48 +22,48 @@ interface IProduce {
      * @param initialState - if a curried function is created and this argument was given, it will be used as fallback if the curried function is called with a state of undefined
      * @returns The next state: a new state, or the current state if nothing was modified
      */
-    <S>(
+    <S, R: S | void>(
         currentState: S,
-        recipe: (draftState: S) => S | void,
+        recipe: (draftState: S) => R,
         patchListener?: PatchListener
-    ): S;
+    ): R;
     // curried invocations with inital state
-    <S, A, B, C>(
-        recipe: (draftState: S, a: A, b: B, c: C) => S | void,
+    <S, A, B, C, R: S | void>(
+        recipe: (draftState: S, a: A, b: B, c: C) => R,
         initialState: S
-    ): (currentState: S | void, a: A, b: B, c: C) => S;
-    <S, A, B>(
-        recipe: (draftState: S, a: A, b: B) => S | void,
+    ): (currentState: S | void, a: A, b: B, c: C) => R;
+    <S, A, B, R: S | void>(
+        recipe: (draftState: S, a: A, b: B) => R,
         initialState: S
-    ): (currentState: S | void, a: A, b: B) => S;
-    <S, A>(
-        recipe: (draftState: S, a: A) => S | void,
+    ): (currentState: S | void, a: A, b: B) => R;
+    <S, A, R: S | void>(
+        recipe: (draftState: S, a: A) => R,
         initialState: S
-    ): (currentState: S | void, a: A) => S;
-    <S>(
-        recipe: (draftState: S) => S | void,
+    ): (currentState: S | void, a: A) => R;
+    <S, R: S | void>(
+        recipe: (draftState: S) => R,
         initialState: S
-    ): (currentState: S | void) => S;
-    <S>(
-        recipe: (draftState: S, ...extraArgs: any[]) => S | void,
+    ): (currentState: S | void) => R;
+    <S, R: S | void>(
+        recipe: (draftState: S, ...extraArgs: any[]) => R,
         initialState: S
-    ): (currentState: S | void, ...extraArgs: any[]) => S;
+    ): (currentState: S | void, ...extraArgs: any[]) => R;
     // curried invocations without inital state
-    <S, A, B, C>(
-        recipe: (draftState: S, a: A, b: B, c: C) => S | void
-    ): (currentState: S, a: A, b: B, c: C) => S;
-    <S, A, B>(
-        recipe: (draftState: S, a: A, b: B) => S | void
-    ): (currentState: S, a: A, b: B) => S;
-    <S, A>(
-        recipe: (draftState: S, a: A) => S | void
-    ): (currentState: S, a: A) => S;
-    <S>(
-        recipe: (draftState: S) => S | void
-    ): (currentState: S) => S;
-    <S>(
-        recipe: (draftState: S, ...extraArgs: any[]) => S | void
-    ): (currentState: S, ...extraArgs: any[]) => S;
+    <S, A, B, C, R: S | void>(
+        recipe: (draftState: S, a: A, b: B, c: C) => R
+    ): (currentState: S, a: A, b: B, c: C) => R;
+    <S, A, B, R: S | void>(
+        recipe: (draftState: S, a: A, b: B) => R
+    ): (currentState: S, a: A, b: B) => R;
+    <S, A, R: S | void>(
+        recipe: (draftState: S, a: A) => R
+    ): (currentState: S, a: A) => R;
+    <S, R: S | void>(
+        recipe: (draftState: S) => R
+    ): (currentState: S) => R;
+    <S, R: S | void>(
+        recipe: (draftState: S, ...extraArgs: any[]) => R
+    ): (currentState: S, ...extraArgs: any[]) => R;
 }
 
 declare export var produce: IProduce


### PR DESCRIPTION
Adds better Flow support. Now, if the return type of the recipe never returns `undefined`, it can be guaranteed that produce won't return `undefined`. This allows compatibility with other types, like Redux's `Reducer` type.

i.e.,

```es6
import type { Reducer } from 'redux'

type State = {| count: number |}

type Action = {| type: 'INCREMENT' |} | {| type: 'DECREMENT' |}

const reducer: Reducer<State, Action> = (state: State = { count: 0 }, action) => {
  switch(action.type) {
    case 'INCREMENT':
      state.count++
      break

    case 'DECREMENT':
      state.count--
  }

  return state
}

// This is now possible! Before it would fail, as the return type of
// produce would be `State | void`.
const initialState: State = produce(reducer)(undefined, { type: 'INCREMENT' })
```