### PR TITLE
feat: always use the return value

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,8 +1,3 @@
-export const NOTHING =
-    typeof Symbol !== "undefined"
-        ? Symbol("immer-nothing")
-        : {["immer-nothing"]: true}
-
 export const DRAFT_STATE =
     typeof Symbol !== "undefined" ? Symbol("immer-state") : "__$immer_state"
 

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -52,15 +52,12 @@ type IsVoidLike<T> =
     | (T extends undefined ? 1 : 0)
     | (T extends void | undefined ? 1 : 0)
 
-/** Converts `nothing` into `undefined` */
-type FromNothing<T> = Nothing extends T ? Exclude<T, Nothing> | undefined : T
-
 /** The inferred return type of `produce` */
 type Produced<Base, Return> = 1 extends HasVoidLike<Return>
     ? 1 extends IsVoidLike<Return>
         ? Base
-        : Base | FromNothing<Exclude<Return, void>>
-    : FromNothing<Return>
+        : Base | Exclude<Return, void>
+    : Return
 
 export interface IProduce {
     /**
@@ -101,17 +98,6 @@ export interface IProduce {
 
 export const produce: IProduce
 export default produce
-
-/** Use a class type for `nothing` so its type is unique */
-declare class Nothing {
-    // This lets us do `Exclude<T, Nothing>`
-    private _: any
-}
-
-/**
- * The sentinel value returned by producers to replace the draft with undefined.
- */
-export const nothing: Nothing
 
 /**
  * Pass true to automatically freeze all copies created by Immer.

--- a/src/immer.js
+++ b/src/immer.js
@@ -8,8 +8,7 @@ import {
     isDraft,
     isDraftable,
     shallowCopy,
-    DRAFT_STATE,
-    NOTHING
+    DRAFT_STATE
 } from "./common"
 
 function verifyMinified() {}
@@ -72,7 +71,7 @@ export class Immer {
                     inversePatches = patchListener && []
 
                 // Finalize the modified draft...
-                if (result === undefined || result === baseDraft) {
+                if (result === baseDraft) {
                     result = this.finalize(
                         baseDraft,
                         [],
@@ -108,8 +107,7 @@ export class Immer {
             }
             patchListener && patchListener(patches, inversePatches)
         }
-        // Normalize the result.
-        return result === NOTHING ? undefined : result
+        return result
     }
     setAutoFreeze(value) {
         this.autoFreeze = value

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,6 @@ export const setUseProxies = value => immer.setUseProxies(value)
  */
 export const applyPatches = produce(applyPatchesImpl)
 
-export {original, isDraft, NOTHING as nothing} from "./common"
+export {original, isDraft} from "./common"
 
 export {Immer}


### PR DESCRIPTION
__Provoked by:__ https://github.com/mweststrate/immer/issues/246

__Goal:__ Simplify the mental model of producers

__Hypothesis:__ When `produce` returns exactly what its recipe function returns (apart from proxies, of course), complexity is reduced for developers (and TypeScript).