### PR TITLE
Ts 3.4 inference improvements

### DIFF
--- a/__tests__/curry.js
+++ b/__tests__/curry.js
@@ -54,6 +54,7 @@ function runTests(name, useProxies) {
 
             expect(reducer(undefined, 3)).toEqual({hello: "world", index: 3})
             expect(reducer({}, 3)).toEqual({index: 3})
+            expect(reducer()).toEqual({hello: "world", index: undefined})
         })
 
         it("can has fun with change detection", () => {

--- a/__tests__/draft.ts
+++ b/__tests__/draft.ts
@@ -1,4 +1,4 @@
-import {Draft, DraftArray} from "../dist/immer.js"
+import {Draft} from "../dist/immer.js"
 
 // For checking if a type is assignable to its draft type (and vice versa)
 declare const toDraft: <T>(value: T) => Draft<T>
@@ -23,7 +23,6 @@ declare const _: any
     // NOTE: As of 3.2.2, everything fails without "extends any"
     const $ = <Value extends any>(val: ReadonlyArray<Value>) => {
         val = _ as Draft<typeof val>
-        val = _ as DraftArray<typeof val>
         let elem: Value = _ as Draft<Value>
     }
 }

--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -70,7 +70,7 @@ it("can update readonly state via standard api", () => {
 
 // NOTE: only when the function type is inferred
 it("can infer state type from default state", () => {
-    type State = {readonly a:number} | boolean
+    type State = {readonly a:number}
     type Recipe = (base?: State | boolean) => State
 
     let foo = produce((x: any) => {}, {} as State)
@@ -323,8 +323,16 @@ it("can work with non-readonly base types", () => {
             done: true
         })
     }
-    const newState2: Immutable<State> = produce(reducer)(state)
-    const newState3: Immutable<State> = produce(reducer, state)()
+
+    // base case for with-initial-state
+    const newState4 = produce(reducer, state)(state)
+    exactType(newState4, {} as State)
+    // no argument case, in that case, immutable version recipe first arg will be inferred
+    const newState5 = produce(reducer, state)()
+    exactType(newState5, {} as Immutable<State>)
+    // we can force the return type of the reducer by passing the generic argument
+    const newState3 = produce(reducer, state)<State>()
+    exactType(newState3, {} as State)
 })
 
 it("can work with readonly base types", () => {
@@ -360,5 +368,15 @@ it("can work with readonly base types", () => {
         })
     }
     const newState2: State = produce(reducer)(state)
-    const newState3: State = produce(reducer, state)()
+    exactType(newState2, {} as State)
+
+    // base case for with-initial-state
+    const newState4 = produce(reducer, state)(state)
+    exactType(newState4, {} as State)
+    // no argument case, in that case, immutable version recipe first arg will be inferred
+    const newState5 = produce(reducer, state)()
+    exactType(newState5, {} as Immutable<State>)
+    // we can force the return type of the reducer by passing the generic argument
+    const newState3 = produce(reducer, state)<State>()
+    exactType(newState3, {} as State)
 })

--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -70,16 +70,16 @@ it("can update readonly state via standard api", () => {
 
 // NOTE: only when the function type is inferred
 it("can infer state type from default state", () => {
-    type State = {readonly a:number}
+    type State = {readonly a: number}
     type Recipe = (base?: State | boolean) => State
 
     let foo = produce((x: any) => {}, {} as State)
-    
+
     type Arg0 = Parameters<typeof foo>[0]
     type L = Parameters<typeof foo>["length"]
     type Return = ReturnType<typeof foo>
     exactType({} as Arg0, {} as (State | undefined))
-    exactType({} as any as L, 0 as (0 | 1))
+    exactType(({} as any) as L, 0 as (0 | 1))
     exactType({} as Return, {} as State)
 })
 
@@ -92,7 +92,7 @@ it("can infer state type from recipe function", () => {
     type L = Parameters<typeof foo>["length"]
     type Return = ReturnType<typeof foo>
     exactType({} as Arg0, {} as State)
-    exactType({} as any as L, 1 as const)
+    exactType(({} as any) as L, 1 as const)
     exactType({} as Return, {} as State)
 })
 
@@ -108,7 +108,7 @@ it("can infer state type from recipe function with arguments", () => {
     type Return = ReturnType<typeof foo>
     exactType({} as Arg0, {} as State)
     exactType({} as Arg1, {} as number)
-    exactType({} as any as L, 2 as const)
+    exactType(({} as any) as L, 2 as const)
     exactType({} as Return, {} as State)
 })
 
@@ -116,14 +116,14 @@ it("can infer state type from recipe function with arguments and initial state",
     type State = {readonly a: string} | {readonly b: string}
 
     let foo = produce((draft: Draft<State>, x: number) => {}, {} as State)
-    
+
     type Arg0 = Parameters<typeof foo>[0]
     type Arg1 = Parameters<typeof foo>[1]
     type L = Parameters<typeof foo>["length"]
     type Return = ReturnType<typeof foo>
     exactType({} as Arg0, {} as (State | undefined))
     exactType({} as Arg1, {} as number)
-    exactType({} as any as L, 2 as const)
+    exactType(({} as any) as L, 2 as const)
     exactType({} as Return, {} as State)
 })
 
@@ -134,7 +134,7 @@ it("cannot infer state type when the function type and default state are missing
     type L = Parameters<typeof foo>["length"]
     type Return = ReturnType<typeof foo>
     exactType({} as Arg0, {} as any)
-    exactType({} as any as L, 1 as const)
+    exactType(({} as any) as L, 1 as const)
     exactType({} as Return, {} as any)
 })
 
@@ -192,14 +192,14 @@ describe("curried producer", () => {
         {
             // No initial state:
             let foo = produce((s: State, a: number, b: number) => {})
-            
+
             type Arg0 = Parameters<typeof foo>[0]
             type Arg1 = Parameters<typeof foo>[1]
             type L = Parameters<typeof foo>["length"]
             type Return = ReturnType<typeof foo>
             exactType({} as Arg0, {} as (State | undefined))
             exactType({} as Arg1, {} as number)
-            exactType({} as any as L, 3 as const)
+            exactType(({} as any) as L, 3 as const)
             exactType({} as Return, {} as State)
 
             foo({} as State, 1, 2)
@@ -214,13 +214,16 @@ describe("curried producer", () => {
             type L = Parameters<typeof woo>["length"]
             type Return = ReturnType<typeof woo>
             exactType({} as Args, {} as [State, ...number[]])
-            exactType({} as any as L, 3 as number)
+            exactType(({} as any) as L, 3 as number)
             exactType({} as Return, {} as State)
         }
 
         {
             // With initial state:
-            let bar = produce((state: Draft<State>, ...args: number[]) => {}, {} as State)
+            let bar = produce(
+                (state: Draft<State>, ...args: number[]) => {},
+                {} as State
+            )
             bar({} as State, 1, 2)
             bar({} as State)
             bar()
@@ -229,21 +232,27 @@ describe("curried producer", () => {
             type L = Parameters<typeof bar>["length"]
             type Return = ReturnType<typeof bar>
             exactType({} as Args, {} as [State?, ...number[]])
-            exactType({} as any as L, 3 as number)
+            exactType(({} as any) as L, 3 as number)
             exactType({} as Return, {} as State)
         }
 
         {
             // When args is a tuple:
-            let tup = produce((state: Draft<State>, ...args: [string, ...number[]]) => {}, {} as State)
-            tup({a: 1}, '', 2)
-            tup(undefined, '', 2)
+            let tup = produce(
+                (state: Draft<State>, ...args: [string, ...number[]]) => {},
+                {} as State
+            )
+            tup({a: 1}, "", 2)
+            tup(undefined, "", 2)
 
             type Args = Parameters<typeof tup>
             type L = Parameters<typeof tup>["length"]
             type Return = ReturnType<typeof tup>
-            exactType({} as Args, {} as [State|undefined, string, ...number[]])
-            exactType({} as any as L, 3 as number)
+            exactType(
+                {} as Args,
+                {} as [State | undefined, string, ...number[]]
+            )
+            exactType(({} as any) as L, 3 as number)
             exactType({} as Return, {} as State)
         }
     })
@@ -258,7 +267,7 @@ describe("curried producer", () => {
             type L = Parameters<typeof foo>["length"]
             type Return = ReturnType<typeof foo>
             exactType({} as Args, {} as [readonly string[]])
-            exactType({} as any as L, 3 as 1)
+            exactType(({} as any) as L, 3 as 1)
             exactType({} as Return, {} as readonly string[])
         }
 
@@ -272,8 +281,8 @@ describe("curried producer", () => {
             type Args = Parameters<typeof bar>
             type L = Parameters<typeof bar>["length"]
             type Return = ReturnType<typeof bar>
-            exactType({} as Args, {} as [((readonly string[])|undefined)?])
-            exactType({} as any as L, 3 as (0|1))
+            exactType({} as Args, {} as [((readonly string[]) | undefined)?])
+            exactType(({} as any) as L, 3 as (0 | 1))
             exactType({} as Return, {} as readonly string[])
         }
     })
@@ -379,14 +388,16 @@ it("works with generic parameters", () => {
 it("can work with non-readonly base types", () => {
     const state = {
         price: 10,
-        todos: [{
-            title: "test",
-            done: false
-        }]
+        todos: [
+            {
+                title: "test",
+                done: false
+            }
+        ]
     }
     type State = typeof state
 
-    const newState: State = produce(state, (draft) => {
+    const newState: State = produce(state, draft => {
         draft.price += 5
         draft.todos.push({
             title: "hi",
@@ -415,22 +426,24 @@ it("can work with non-readonly base types", () => {
 
 it("can work with readonly base types", () => {
     type State = {
-        readonly price: number;
+        readonly price: number
         readonly todos: readonly {
-            readonly title: string;
-            readonly done: boolean;
-        }[];
+            readonly title: string
+            readonly done: boolean
+        }[]
     }
 
     const state: State = {
         price: 10,
-        todos: [{
-            title: "test",
-            done: false
-        }]
+        todos: [
+            {
+                title: "test",
+                done: false
+            }
+        ]
     }
 
-    const newState: State = produce(state, (draft) => {
+    const newState: State = produce(state, draft => {
         draft.price + 5
         draft.todos.push({
             title: "hi",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^24.7.1",
     "lodash": "^4.17.4",
     "lodash.clonedeep": "^4.5.0",
-    "prettier": "^1.9.2",
+    "prettier": "1.17.0",
     "pretty-quick": "^1.8.0",
     "regenerator-runtime": "^0.11.1",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "regenerator-runtime": "^0.11.1",
     "rimraf": "^2.6.2",
     "seamless-immutable": "^7.1.3",
-    "typescript": "3.1.1",
+    "typescript": "3.4.3",
     "yarn-or-npm": "^2.0.4"
   },
   "jest": {

--- a/readme.md
+++ b/readme.md
@@ -531,14 +531,14 @@ Plain objects and arrays are always drafted by Immer.
 Every other object must use the `immerable` symbol to mark itself as compatible with Immer. When one of these objects is mutated within a producer, its prototype is preserved between copies.
 
 ```js
-import {immerable} from 'immer'
+import {immerable} from "immer"
 
 class Foo {
-  [immerable] = true // Option 1
+    [immerable] = true // Option 1
 
-  constructor() {
-    this[immerable] = true // Option 2
-  }
+    constructor() {
+        this[immerable] = true // Option 2
+    }
 }
 
 Foo[immerable] = true // Option 3
@@ -600,7 +600,7 @@ const state: State = {
     x: 0
 }
 
-const newState = produce<State>(state, draft => {
+const newState = produce(state, draft => {
     // `x` can be modified here
     draft.x++
 })
@@ -610,7 +610,30 @@ const newState = produce<State>(state, draft => {
 
 This ensures that the only place you can modify your state is in your produce callbacks. It even works recursively and with `ReadonlyArray`s!
 
-**Note:** Immer v1.9+ supports Typescript v3.1+ only.
+For curried reducers, the type is inferred from the first argument of recipe function, so make sure to type it. The `Draft` utility type can be used if the state argument type is immutable:
+
+```ts
+import produce, {Draft} from "immer"
+
+interface State {
+    readonly x: number
+}
+
+// `x` cannot be modified here
+const state: State = {
+    x: 0
+}
+
+const increment = produce((draft: Draft<State>, inc: number) => {
+    // `x` can be modified here
+    draft.x += inc
+})
+
+const newState = increment(state, 2)
+// `newState.x` cannot be modified here
+```
+
+**Note:** Immer v1.9+ supports Typescript v3.1+ only. **Note:** Immer v2.2+ supports Typescript v3.4+ only.
 
 ## Using `this`
 
@@ -735,6 +758,10 @@ Most important observation:
 **Immer 1.\* -> 2.0**
 
 Make sure you don't return any promises as state, because `produce` will actually invoke the promise and wait until it settles.
+
+**Immer 2.1 -> 2.2**
+
+When using TypeScript, for curried reducers that are typed in the form `produce<Type>((arg) => { })`, rewrite this to `produce((arg: Type) => { })` or `produce((arg: Draft<Type>) => { })` for correct inference.
 
 ## FAQ
 

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -75,7 +75,10 @@ export interface IProduce {
         T = Params[0],
     >(
         recipe: Recipe,
-    ): (state: Immutable<T>, ...rest: Tail<Params>) => Produced<Immutable<T>, ReturnType<Recipe>>
+    ): <S extends Immutable<T>>(state: S, ...rest: Tail<Params>) => Produced<S, ReturnType<Recipe>>
+    //   ^ by making the returned type generic, the actual type of the passed in object is preferred 
+    //     over the type used in the recipe. However, it does have to satisfy the immutable version used in the recipe
+    //     Note: the type of S is the widened version of T, so it can have more props than T, but that is technically actually correct!
 
     /** Curried producer with initial state */
     <
@@ -84,8 +87,8 @@ export interface IProduce {
         T = Params[0],
     >(
         recipe: Recipe,
-        initialState: T
-    ): (state?: Immutable<T>, ...rest: Tail<Params>) => Produced<Immutable<T>, ReturnType<Recipe>>
+        initialState: Immutable<T>
+    ): <S extends Immutable<T>>(state?: S, ...rest: Tail<Params>) => Produced<S, ReturnType<Recipe>>
 
     /** Normal producer */
     <Base, D = Draft<Base>, Return = void>(

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -1,4 +1,7 @@
-type Tail<T extends any[]> = ((...t: T) => any) extends ((_: any, ...tail: infer TT) => any)
+type Tail<T extends any[]> = ((...t: T) => any) extends ((
+    _: any,
+    ...tail: infer TT
+) => any)
     ? TT
     : []
 
@@ -17,18 +20,17 @@ type AtomicObject =
     | String
 
 export type Draft<T> = T extends AtomicObject
-  ? T
-  : T extends object
-  ? { -readonly [K in keyof T]: Draft<T[K]> }
-  : T // mostly: unknown & any
+    ? T
+    : T extends object
+    ? {-readonly [K in keyof T]: Draft<T[K]>}
+    : T // mostly: unknown & any
 
 /** Convert a mutable type into a readonly type */
-export type Immutable<T> =
-  T extends AtomicObject
-  ? T
-  : T extends object
-  ? { readonly [K in keyof T]: Immutable<T[K]> }
-  : T
+export type Immutable<T> = T extends AtomicObject
+    ? T
+    : T extends object
+    ? {readonly [K in keyof T]: Immutable<T[K]>}
+    : T
 
 export interface Patch {
     op: "replace" | "remove" | "add"
@@ -72,11 +74,14 @@ export interface IProduce {
     <
         Recipe extends (...args: any[]) => any,
         Params extends any[] = Parameters<Recipe>,
-        T = Params[0],
+        T = Params[0]
     >(
-        recipe: Recipe,
-    ): <S extends Immutable<T>>(state: S, ...rest: Tail<Params>) => Produced<S, ReturnType<Recipe>>
-    //   ^ by making the returned type generic, the actual type of the passed in object is preferred 
+        recipe: Recipe
+    ): <S extends Immutable<T>>(
+        state: S,
+        ...rest: Tail<Params>
+    ) => Produced<S, ReturnType<Recipe>>
+    //   ^ by making the returned type generic, the actual type of the passed in object is preferred
     //     over the type used in the recipe. However, it does have to satisfy the immutable version used in the recipe
     //     Note: the type of S is the widened version of T, so it can have more props than T, but that is technically actually correct!
 
@@ -84,11 +89,14 @@ export interface IProduce {
     <
         Recipe extends (...args: any[]) => any,
         Params extends any[] = Parameters<Recipe>,
-        T = Params[0],
+        T = Params[0]
     >(
         recipe: Recipe,
         initialState: Immutable<T>
-    ): <S extends Immutable<T>>(state?: S, ...rest: Tail<Params>) => Produced<S, ReturnType<Recipe>>
+    ): <S extends Immutable<T>>(
+        state?: S,
+        ...rest: Tail<Params>
+    ) => Produced<S, ReturnType<Recipe>>
 
     /** Normal producer */
     <Base, D = Draft<Base>, Return = void>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6049,10 +6049,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 uglify-js@^3.1.4:
   version "3.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,10 +4993,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.9.2:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 pretty-format@^24.7.0:
   version "24.7.0"


### PR DESCRIPTION
Improved type inference a bit:

* Required version is upped to 3.4
* Draft and Immutable have become simpler, as suggest in #325, which is possible since 3.4
* Type inference for curried `produce` has improved. Especially the rest parameters are now better typed and has less edge cases (before at random places `| boolean` was added to the type inference, and rest arguments remained optional`
  * As a result `produce<State>(fn)` no longer works, however, `produce((x: Draft<State>))` will lead to the correct inference

@aleclarson feel free to shoot at it! I think especially for currying type inference is now better and a bit more predictable, but this change is also kinda breaking on how to type producers