### PR TITLE
Add unpkg and jsdelivr fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Create your next immutable state by mutating the current one",
   "main": "dist/immer.js",
   "umd:main": "dist/immer.umd.js",
+  "unpkg": "dist/immer.umd.js",
+  "jsdelivr": "dist/immer.umd.js",
   "module": "dist/immer.module.js",
   "jsnext:main": "dist/immer.module.js",
   "react-native": "dist/immer.module.js",


### PR DESCRIPTION
Immer already has a UMD build, which is great! This PR adds jsdelivr and unpkg fields in package.json pointing to the same place, so jsdelivr.com and unpkg.com respectively can automatically serve the right files, and AMD implementations that depend on one or both of those (like d3-require) can automatically load immer directly or as a dependency.