### PR TITLE
feat: export "produceRO" for 100% immutable returns

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "rimraf": "^2.6.2",
     "seamless-immutable": "^7.1.3",
     "spec.ts": "^1.1.0",
-    "typescript": "3.4.3",
+    "typescript": "3.5.1",
     "yarn-or-npm": "^2.0.4"
   },
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,11 @@ export const produce = immer.produce
 export default produce
 
 /**
+ * Same as `produce` except the return type is always immutable!
+ */
+export const produceRO = produce
+
+/**
  * Pass true to automatically freeze all copies created by Immer.
  *
  * By default, auto-freezing is disabled in production.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6054,10 +6054,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+typescript@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4:
   version "3.5.3"


### PR DESCRIPTION
This provides a way to opt-in for `produce` to always wrap your base type with `Immutable<T>` so the return type is 100% immutable.

**Note:** TypeScript support for creating generic function types within conditionals is **not** possible yet.

Closes #381