### PR TITLE
immer-reducer works with React useReducer hook too

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -656,7 +656,7 @@ const newState = increment(state, 2)
 -   [bey](https://github.com/jamiebuilds/bey) _Simple immutable state for React using Immer_
 -   [immer-wieder](https://github.com/drcmda/immer-wieder#readme) _State management lib that combines React 16 Context and immer for Redux semantics_
 -   [robodux](https://github.com/neurosnap/robodux) _flexible way to reduce redux boilerplate_
--   [immer-reducer](https://github.com/epeli/immer-reducer) _Type-safe and terse Redux reducers with Typescript_
+-   [immer-reducer](https://github.com/epeli/immer-reducer) _Type-safe and terse React (useReducer()) and Redux reducers with Typescript_
 -   [redux-ts-utils](https://github.com/knpwrs/redux-ts-utils) _Everything you need to create type-safe applications with Redux with a strong emphasis on simplicity_
 -   [react-state-tree](https://github.com/suchipi/react-state-tree) _Drop-in replacement for useState that persists your state into a redux-like state tree_
 -   [redux-immer](https://github.com/salvoravida/redux-immer) _is used to create an equivalent function of Redux combineReducers that works with `immer` state. Like `redux-immutable` but for `immer`_


### PR DESCRIPTION
Just realized that immer-reducer works with the React useReducer hook just fine because it is just a reducer generation lib and no deps with Redux whatsoever.

https://github.com/epeli/immer-reducer#-react-hooks