### PR TITLE
auto-own createDraft drafts when assigning through proxies (#393)

### DIFF
--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -132,5 +132,49 @@ function runTests(name, useProxies) {
 			finishDraft(draft)
 			expect(() => finishDraft(draft)).toThrowErrorMatchingSnapshot()
 		})
+
+		describe("attach to existing draft", () => {
+			describe("array assign", () => {
+				const b = [{foo: "bar"}, {foo: "baz"}]
+				const c = produce(b, bb => {
+					bb[1] = createDraft({foo: "quux"})
+					expect(isDraft(bb[1])).toBe(true)
+				})
+				expect(c.length).toEqual(2)
+				expect(isDraft(c[1])).toBe(false)
+			})
+			describe("array push", () => {
+				const b = [{foo: "bar"}, {foo: "baz"}]
+				const c = produce(b, bb => {
+					bb.push(createDraft({foo: "quux"}))
+					expect(isDraft(bb[2])).toBe(true)
+				})
+				expect(c.length).toEqual(3)
+				expect(isDraft(c[2])).toBe(false)
+			})
+			describe("object set existing", () => {
+				const b = {foo: {bar: "baz"}}
+				const c = produce(b, bb => {
+					const foo2 = createDraft(Object.freeze({bar: "quux"}))
+					expect(foo2.bar).toEqual("quux")
+
+					foo2.bar = "zip"
+					expect(foo2.bar).toEqual("zip")
+
+					bb.foo = foo2
+					expect(isDraft(bb.foo)).toBe(true)
+				})
+				expect(isDraft(c.foo)).toBe(false)
+				expect(c.foo.bar).toEqual("zip")
+			})
+			describe("object set new", () => {
+				const b = {foo: {bar: "baz"}}
+				const c = produce(b, bb => {
+					bb.bar = createDraft({baz: "quux"})
+					expect(isDraft(bb.bar)).toBe(true)
+				})
+				expect(isDraft(c.bar)).toBe(false)
+			})
+		})
 	})
 }

--- a/src/es5.js
+++ b/src/es5.js
@@ -101,6 +101,21 @@ function set(state, prop, value) {
 		prepareCopy(state)
 	}
 	state.copy[prop] = value
+	takeOwnershipIfNeeded(state, value)
+}
+
+function takeOwnershipIfNeeded(state, value) {
+	if (!isDraft(value)) return
+	const child = value[DRAFT_STATE]
+	if (!child.isManual) return
+
+	// set child state as if it were created from this object
+	child.parent = state
+	state.scope.drafts.push(...child.scope.drafts)
+	child.scope = state.scope
+
+	if (child.modified) markChanged(state)
+	child.isManual = false
 }
 
 function markChanged(state) {

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -155,6 +155,8 @@ export function applyPatches<S>(base: S, patches: Patch[]): S
 /**
  * Create an Immer draft from the given base state, which may be a draft itself.
  * The draft can be modified until you finalize it with the `finishDraft` function.
+ * If the draft is assigned to an existing draft, it will be finalized when that
+ * draft is finalized.
  */
 export function createDraft<T>(base: T): Draft<T>
 

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -148,7 +148,22 @@ function set(state, prop, value) {
 	}
 	state.assigned[prop] = true
 	state.copy[prop] = value
+	takeOwnershipIfNeeded(state, value)
 	return true
+}
+
+function takeOwnershipIfNeeded(state, value) {
+	if (!isDraft(value)) return
+	const child = value[DRAFT_STATE]
+	if (!child.isManual) return
+
+	// set child state as if it were created from this object
+	child.parent = state
+	state.scope.drafts.push(...child.scope.drafts)
+	child.scope = state.scope
+
+	if (child.modified) markChanged(state)
+	child.isManual = false
 }
 
 function deleteProperty(state, prop) {


### PR DESCRIPTION
Heads up, tests fail for the es5 implementation when assigning to new fields. I am not sure how to solve that. 

TBH, as I understand the es5 version, it's unsolvable. Feels like a potential compromise and/or footgun to just not support it for es5 because at the same time, it'd be great to have this working in environments that can use native proxies.

Fixes #393.