### PR TITLE
Several fixes to patch generation

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -156,6 +156,9 @@ function deleteProperty(state, prop) {
 	if (peek(state.base, prop) !== undefined || prop in state.base) {
 		state.assigned[prop] = false
 		markChanged(state)
+	} else if (state.assigned[prop]) {
+		// if an originally not assigned property was deleted
+		delete state.assigned[prop]
 	}
 	if (state.copy) delete state.copy[prop]
 	return true


### PR DESCRIPTION
Fixed an issue where adding and then deleting a property generated the wrong patches; in Proxy implementation, it generated an `add` patch with value `undefined`. 

Fixed an issue where replaying patches on a draft in a producer, where in the middle there was an 'entire state replacement' patch, this new state could not be returned, as both the draft would be modified and a new state would be returned. Nice benefit of this fix is that any patch before a replacement won't even be replayed. 