### PR TITLE
BREAKING CHANGE: In development mode, any new value stored in a tree will be deeply frozen

### DIFF
--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -51,14 +51,6 @@ function runTests(name, useProxies) {
 				expect(isFrozen(next.a)).toBeTruthy()
 			})
 
-			it("a new object replaces a primitive base", () => {
-				const obj = {a: {}}
-				const next = produce(null, () => obj)
-				expect(next).toBe(obj)
-				expect(isFrozen(next)).toBeTruthy()
-				expect(isFrozen(next.a)).toBeTruthy()
-			})
-
 			it("a new object replaces the entire draft", () => {
 				const obj = {a: {b: {}}}
 				const next = produce({}, () => obj)
@@ -90,37 +82,43 @@ function runTests(name, useProxies) {
 				expect(isFrozen(next.a.b)).toBeTruthy()
 				expect(isFrozen(next.a.b.c)).toBeTruthy()
 			})
-		})
-
-		describe("the result is never auto-frozen when", () => {
-			it("the producer is a no-op", () => {
-				const base = {a: {}}
-				const next = produce(base, () => {})
-				expect(next).toBe(base)
-				expect(isFrozen(next)).toBeFalsy()
-				expect(isFrozen(next.a)).toBeFalsy()
-			})
-
-			it("the root draft is returned", () => {
-				const base = {a: {}}
-				const next = produce(base, draft => draft)
-				expect(next).toBe(base)
-				expect(isFrozen(next)).toBeFalsy()
-				expect(isFrozen(next.a)).toBeFalsy()
-			})
 
 			it("a nested draft is returned", () => {
 				const base = {a: {}}
 				const next = produce(base, draft => draft.a)
 				expect(next).toBe(base.a)
-				expect(isFrozen(next)).toBeFalsy()
+				expect(isFrozen(next)).toBeTruthy()
 			})
 
 			it("the base state is returned", () => {
 				const base = {}
 				const next = produce(base, () => base)
 				expect(next).toBe(base)
-				expect(isFrozen(next)).toBeFalsy()
+				expect(isFrozen(next)).toBeTruthy()
+			})
+
+			it("the producer is a no-op", () => {
+				const base = {a: {}}
+				const next = produce(base, () => {})
+				expect(next).toBe(base)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+			})
+
+			it("the root draft is returned", () => {
+				const base = {a: {}}
+				const next = produce(base, draft => draft)
+				expect(next).toBe(base)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+			})
+
+			it("a new object replaces a primitive base", () => {
+				const obj = {a: {}}
+				const next = produce(null, () => obj)
+				expect(next).toBe(obj)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
 			})
 		})
 

--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -50,21 +50,63 @@ function runTests(name, useProxies) {
 				expect(isFrozen(next)).toBeTruthy()
 				expect(isFrozen(next.a)).toBeTruthy()
 			})
+
+			it("a new object replaces a primitive base", () => {
+				const obj = {a: {}}
+				const next = produce(null, () => obj)
+				expect(next).toBe(obj)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+			})
+
+			it("a new object replaces the entire draft", () => {
+				const obj = {a: {b: {}}}
+				const next = produce({}, () => obj)
+				expect(next).toBe(obj)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+				expect(isFrozen(next.a.b)).toBeTruthy()
+			})
+
+			it("a new object is added to the root draft", () => {
+				const base = {}
+				const next = produce(base, draft => {
+					draft.a = {b: []}
+				})
+				expect(next).not.toBe(base)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+				expect(isFrozen(next.b)).toBeTruthy()
+			})
+
+			it("a new object is added to a nested draft", () => {
+				const base = {a: {}}
+				const next = produce(base, draft => {
+					draft.a.b = {c: {}}
+				})
+				expect(next).not.toBe(base)
+				expect(isFrozen(next)).toBeTruthy()
+				expect(isFrozen(next.a)).toBeTruthy()
+				expect(isFrozen(next.a.b)).toBeTruthy()
+				expect(isFrozen(next.a.b.c)).toBeTruthy()
+			})
 		})
 
 		describe("the result is never auto-frozen when", () => {
 			it("the producer is a no-op", () => {
-				const base = {}
+				const base = {a: {}}
 				const next = produce(base, () => {})
 				expect(next).toBe(base)
 				expect(isFrozen(next)).toBeFalsy()
+				expect(isFrozen(next.a)).toBeFalsy()
 			})
 
 			it("the root draft is returned", () => {
-				const base = {}
+				const base = {a: {}}
 				const next = produce(base, draft => draft)
 				expect(next).toBe(base)
 				expect(isFrozen(next)).toBeFalsy()
+				expect(isFrozen(next.a)).toBeFalsy()
 			})
 
 			it("a nested draft is returned", () => {
@@ -79,43 +121,6 @@ function runTests(name, useProxies) {
 				const next = produce(base, () => base)
 				expect(next).toBe(base)
 				expect(isFrozen(next)).toBeFalsy()
-			})
-
-			it("a new object replaces a primitive base", () => {
-				const obj = {}
-				const next = produce(null, () => obj)
-				expect(next).toBe(obj)
-				expect(isFrozen(next)).toBeFalsy()
-			})
-
-			it("a new object replaces the entire draft", () => {
-				const obj = {a: {b: {}}}
-				const next = produce({}, () => obj)
-				expect(next).toBe(obj)
-				expect(isFrozen(next)).toBeFalsy()
-				expect(isFrozen(next.a)).toBeFalsy()
-				expect(isFrozen(next.a.b)).toBeFalsy()
-			})
-
-			it("a new object is added to the root draft", () => {
-				const base = {}
-				const next = produce(base, draft => {
-					draft.a = {}
-				})
-				expect(next).not.toBe(base)
-				expect(isFrozen(next)).toBeTruthy()
-				expect(isFrozen(next.a)).toBeFalsy()
-			})
-
-			it("a new object is added to a nested draft", () => {
-				const base = {a: {}}
-				const next = produce(base, draft => {
-					draft.a.b = {}
-				})
-				expect(next).not.toBe(base)
-				expect(isFrozen(next)).toBeTruthy()
-				expect(isFrozen(next.a)).toBeTruthy()
-				expect(isFrozen(next.a.b)).toBeFalsy()
 			})
 		})
 

--- a/readme.md
+++ b/readme.md
@@ -548,6 +548,8 @@ isDraft(nextState) // => false
 
 Immer automatically freezes any state trees that are modified using `produce`. This protects against accidental modifications of the state tree outside of a producer. This comes with a performance impact, so it is recommended to disable this option in production. It is by default enabled. By default, it is turned on during local development and turned off in production. Use `setAutoFreeze(true / false)` to explicitly turn this feature on or off.
 
+_⚠️ If auto freezing is enabled, recipes are not entirely side-effect free: Any plain object or array that ends up in the produced result, will be frozen, even when these objects were not frozen before the start of the producer! ⚠️_
+
 ## Immer on older JavaScript environments?
 
 By default `produce` tries to use proxies for optimal performance. However, on older JavaScript engines `Proxy` is not available. For example, when running Microsoft Internet Explorer or React Native (< v0.59) on Android. In such cases, Immer will fallback to an ES5 compatible implementation which works identical, but is a bit slower.

--- a/src/common.js
+++ b/src/common.js
@@ -122,10 +122,8 @@ export function clone(obj) {
 }
 
 export function deepFreeze(obj) {
-	if (!isDraftable(obj)) return
-	if (Object.isFrozen(obj)) return
-	if (isDraft(obj)) return
+	if (!isDraftable(obj) || isDraft(obj) || Object.isFrozen(obj)) return
 	Object.freeze(obj)
 	if (Array.isArray(obj)) obj.forEach(deepFreeze)
-	for (const key in obj) deepFreeze(obj[key])
+	else for (const key in obj) deepFreeze(obj[key])
 }

--- a/src/common.js
+++ b/src/common.js
@@ -120,3 +120,12 @@ export function clone(obj) {
 	for (const key in obj) cloned[key] = clone(obj[key])
 	return cloned
 }
+
+export function deepFreeze(obj) {
+	if (!isDraftable(obj)) return
+	if (Object.isFrozen(obj)) return
+	if (isDraft(obj)) return
+	Object.freeze(obj)
+	if (Array.isArray(obj)) obj.forEach(deepFreeze)
+	for (const key in obj) deepFreeze(obj[key])
+}

--- a/src/immer.js
+++ b/src/immer.js
@@ -304,7 +304,6 @@ export class Immer {
 			// Search new objects for unfinalized drafts. Frozen objects should never contain drafts.
 			else if (isDraftable(value) && !Object.isFrozen(value)) {
 				each(value, finalizeProperty)
-				// for externally incoming object trees, we wan't to make sure they're frozen automatically
 				this.maybeFreeze(value)
 			}
 


### PR DESCRIPTION
* [x] Fix #412 #363  #260 #230 
* [x] probably also fix #313, #229 as we will have now side effects during the execution of recipes anyway
* [x] document the side effect with autofreeze enabled!