### PR TITLE
Use legacy proxies if Proxy.revocable is not defined. Fixes #435

### DIFF
--- a/src/immer.js
+++ b/src/immer.js
@@ -19,7 +19,10 @@ import {ImmerScope} from "./scope"
 function verifyMinified() {}
 
 const configDefaults = {
-	useProxies: typeof Proxy !== "undefined" && typeof Reflect !== "undefined",
+	useProxies:
+		typeof Proxy !== "undefined" &&
+		typeof Proxy.revocable !== "undefined" &&
+		typeof Reflect !== "undefined",
 	autoFreeze:
 		typeof process !== "undefined"
 			? process.env.NODE_ENV !== "production"


### PR DESCRIPTION
Some older browsers including Firefox 24 have support for `Proxy`, but not `Proxy.revocable`. This ensures that we fall back on the legacy browser behavior when `Proxy.revocable` is missing.