### PR TITLE
remove non-existent import

### DIFF
--- a/src/patches.js
+++ b/src/patches.js
@@ -1,5 +1,4 @@
 import {each, clone} from "./common"
-import {createDraft} from "./immer"
 
 export function generatePatches(state, basePath, patches, inversePatches) {
 	Array.isArray(state.base)


### PR DESCRIPTION
I noticed this errant import while working on this repo locally. It looks like it causes rollup/bili warnings. 

```
warning circular_dependency: Circular dependency: src/immer.js -> src/patches.js -> src/immer.js
warning non_existent_export: Non-existent export 'createDraft' is imported from src/immer.js
```