### PR TITLE
Fixing #472 (In proxy, Freezed Maps don't become draft)

### DIFF
--- a/__tests__/__snapshots__/manual.js.snap
+++ b/__tests__/__snapshots__/manual.js.snap
@@ -50,7 +50,7 @@ Array [
 ]
 `;
 
-exports[`manual - proxy cannot modify after finish 1`] = `"Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":2}"`;
+exports[`manual - proxy cannot modify after finish 1`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
 exports[`manual - proxy should check arguments 1`] = `"First argument to \`createDraft\` must be a plain object, an array, or an immerable object"`;
 
@@ -60,7 +60,7 @@ exports[`manual - proxy should check arguments 3`] = `"First argument to \`finis
 
 exports[`manual - proxy should not finish drafts from produce 1`] = `"First argument to \`finishDraft\` must be a draft returned by \`createDraft\`"`;
 
-exports[`manual - proxy should not finish twice 1`] = `"The given draft is already finalized"`;
+exports[`manual - proxy should not finish twice 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
 exports[`manual - proxy should support patches drafts 1`] = `
 Array [

--- a/__tests__/curry.js
+++ b/__tests__/curry.js
@@ -6,7 +6,9 @@ runTests("es5", false)
 
 function runTests(name, useProxies) {
 	describe("curry - " + name, () => {
-		setUseProxies(useProxies)
+		beforeAll(() => {
+			setUseProxies(useProxies)
+		})
 
 		it("should check arguments", () => {
 			expect(() => produce()).toThrowErrorMatchingSnapshot()

--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -174,5 +174,28 @@ function runTests(name, useProxies) {
 			// In draft, still editable
 			expect(produce(res, d => void d.add(2))).not.toBe(res)
 		})
+
+		it("Map#get() of frozen object will became draftable", () => {
+			const base = {
+				map: new Map([
+					["a", new Map([["a", true], ["b", true], ["c", true]])],
+					["b", new Map([["a", true]])],
+					["c", new Map([["a", true]])]
+				])
+			}
+
+			// This will freeze maps
+			const frozen = produce(base, draft => {})
+
+			// https://github.com/immerjs/immer/issues/472
+			produce(frozen, draft => {
+				// if (useProxies) debugger
+				;["b", "c"].forEach(other => {
+					const m = draft.map.get(other)
+
+					m.delete("a")
+				})
+			})
+		})
 	})
 }

--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -8,8 +8,10 @@ runTests("es5", false)
 
 function runTests(name, useProxies) {
 	describe("auto freeze - " + name, () => {
-		setUseProxies(useProxies)
-		setAutoFreeze(true)
+		beforeAll(() => {
+			setUseProxies(useProxies)
+			setAutoFreeze(true)
+		})
 
 		it("never freezes the base state", () => {
 			const base = {arr: [1], obj: {a: 1}}
@@ -136,7 +138,7 @@ function runTests(name, useProxies) {
 
 		it("will freeze maps", () => {
 			const base = new Map()
-			debugger
+
 			const res = produce(base, draft => {
 				draft.set("a", 1)
 			})

--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -12,7 +12,9 @@ runTests("es5", false)
 
 function runTests(name, useProxies) {
 	describe("manual - " + name, () => {
-		setUseProxies(useProxies)
+		beforeAll(() => {
+			setUseProxies(useProxies)
+		})
 
 		it("should check arguments", () => {
 			expect(() => createDraft(3)).toThrowErrorMatchingSnapshot()

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -242,9 +242,16 @@ const mapTraps = makeTrapsForGetters({
 			cb.call(thisArg, value, key, map)
 		}),
 	get: state => key => {
-		const drafts = state[state.modified ? "copy" : "drafts"]
+		const drafts = state.modified ? state.copy : state.drafts
+
 		if (drafts.has(key)) {
-			return drafts.get(key)
+			const value = drafts.get(key)
+
+			if (isDraft(value) || !isDraftable(value)) return value
+
+			const draft = createProxy(value, state)
+			drafts.set(key, draft)
+			return draft
 		}
 
 		const value = latest(state).get(key)


### PR DESCRIPTION
This PR fixes #472, which in cases `Map`s throw. The problem that the test was pass before fix, even though in [the browser](https://codesandbox.io/s/icy-frog-flbdu) it would throw, not sure why.

Also, even tough it fixes the issue, I'm not sure this the root of problem. This solution might be only a patch.

Help is welcome in navigating Immer