### PR TITLE
Added check for async produce action as part of produceWithPatches

### DIFF
--- a/src/immer.js
+++ b/src/immer.js
@@ -115,6 +115,11 @@ export class Immer {
 			patches = p
 			inversePatches = ip
 		})
+		if (typeof Promise !== "undefined" && nextState instanceof Promise) {
+			return nextState.then(
+				nextState => [nextState, patches, inversePatches]
+			)
+		}
 		return [nextState, patches, inversePatches]
 	}
 	createDraft(base) {


### PR DESCRIPTION
Currently produceWithPatches does not support async recipes being passed in. 

Patches are undefined whilst the resulting state is a promise.

See: https://codesandbox.io/s/immer-sandbox-qlynl?expanddevtools=1&fontsize=14&hidenavigation=1&module=%2Fsrc%2Findex.ts&moduleview=1&theme=dark