### PR TITLE
build: Enable sourcemaps and declaration maps in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "strict": true,
     "declaration": true,
     "importHelpers": false,
+    "sourceMap": true,
+    "declarationMap": true,
     "noImplicitAny": false // TODO: true,
   }
 }


### PR DESCRIPTION
Fixes #489 by enabling sourcemaps in tsconfig.json. 

While we're in the neighborhood, this PR also enables declaration maps, which are auto-generated sourcemaps for .d.ts files. Declaration maps enable the "Go To Definition" (F12) feature of VSCode, CodeSandbox, and other IDEs to navigate to the actual immer implementation code. Without declaration maps, the user only can only navigate to the .d.ts file when "Go To Definition" is used.