### PR TITLE
Make explicit use of TypeScript's ReadonlySet and ReadonlyMap types. Fixes #494.

### DIFF
--- a/__tests__/draft.ts
+++ b/__tests__/draft.ts
@@ -187,6 +187,13 @@ test("draft.ts", () => {
 		assert(fromDraft(toDraft(weak)), weak)
 	}
 
+	// ReadonlyMap instance
+	{
+		let val: ReadonlyMap<any, any> = _
+		let draft: Map<any, any> = _
+		assert(toDraft(val), draft)
+	}
+
 	// Set instance
 	{
 		let val: Set<any> = _
@@ -197,6 +204,13 @@ test("draft.ts", () => {
 		let weak: WeakSet<any> = _
 		assert(toDraft(weak), weak)
 		assert(fromDraft(toDraft(weak)), weak)
+	}
+
+	// ReadonlySet instance
+	{
+		let val: ReadonlySet<any> = _
+		let draft: Set<any> = _
+		assert(toDraft(val), draft)
 	}
 
 	// Promise object

--- a/__tests__/immutable.ts
+++ b/__tests__/immutable.ts
@@ -56,5 +56,41 @@ test("types are ok", () => {
 		assert(val, _ as {readonly a: {readonly b: string}})
 	}
 
+	// Map
+	{
+		let val = _ as Immutable<Map<string, string>>
+		assert(val, _ as ReadonlyMap<string, string>)
+	}
+
+	// Already immutable Map
+	{
+		let val = _ as Immutable<ReadonlyMap<string, string>>
+		assert(val, _ as ReadonlyMap<string, string>)
+	}
+
+	// object in Map
+	{
+		let val = _ as Immutable<Map<{a: string}, {b: string}>>
+		assert(val, _ as ReadonlyMap<{readonly a: string}, {readonly b: string}>)
+	}
+
+	// Set
+	{
+		let val = _ as Immutable<Set<string>>
+		assert(val, _ as ReadonlySet<string>)
+	}
+
+	// Already immutable Set
+	{
+		let val = _ as Immutable<ReadonlySet<string>>
+		assert(val, _ as ReadonlySet<string>)
+	}
+
+	// object in Set
+	{
+		let val = _ as Immutable<Set<{a: string}>>
+		assert(val, _ as ReadonlySet<{readonly a: string}>)
+	}
+
 	expect(true).toBe(true)
 })

--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -438,12 +438,28 @@ it("works with readonly Map and Set", () => {
 	const s = new Set<S>([{x: 2}])
 
 	const res1 = produce(m, (draft: Draft<Map<string, S>>) => {
-		assert(draft, _ as Map<string, {readonly x: number}>) // TODO: drop readonly in TS 3.7
+		assert(draft, _ as Map<string, {x: number}>)
 	})
 	assert(res1, _ as Map<string, {readonly x: number}>)
 
 	const res2 = produce(s, (draft: Draft<Set<S>>) => {
-		assert(draft, _ as Set<{readonly x: number}>) // TODO: drop readonly in TS 3.7
+		assert(draft, _ as Set<{x: number}>)
 	})
 	assert(res2, _ as Set<{readonly x: number}>)
+})
+
+it("works with ReadonlyMap and ReadonlySet", () => {
+	type S = {readonly x: number}
+	const m: ReadonlyMap<string, S> = new Map([["a", {x: 1}]])
+	const s: ReadonlySet<S> = new Set([{x: 2}])
+
+	const res1 = produce(m, (draft: Draft<Map<string, S>>) => {
+		assert(draft, _ as Map<string, {x: number}>)
+	})
+	assert(res1, _ as ReadonlyMap<string, {readonly x: number}>)
+
+	const res2 = produce(s, (draft: Draft<Set<S>>) => {
+		assert(draft, _ as Set<{x: number}>)
+	})
+	assert(res2, _ as ReadonlySet<{readonly x: number}>)
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,6 @@ type Tail<T extends any[]> = ((...t: T) => any) extends ((
 /** Object types that should never be mapped */
 type AtomicObject =
 	| Function
-	| WeakMap<any, any>
-	| WeakSet<any>
 	| Promise<any>
 	| Date
 	| RegExp
@@ -30,36 +28,36 @@ type AtomicObject =
 	| Number
 	| String
 
+/**
+ * These should also never be mapped but must be tested after regular Map and
+ * Set
+ */
+type WeakReferences = WeakMap<any, any> | WeakSet<any>
+
 export type Draft<T> = T extends AtomicObject
 	? T
-	: T extends Map<infer K, infer V>
-	? DraftMap<K, V>
-	: T extends Set<infer V>
-	? DraftSet<V>
+	: T extends ReadonlyMap<infer K, infer V> // Map extends ReadonlyMap
+	? Map<Draft<K>, Draft<V>>
+	: T extends ReadonlySet<infer V> // Set extends ReadonlySet
+	? Set<Draft<V>>
+	: T extends WeakReferences
+	? T
 	: T extends object
 	? {-readonly [K in keyof T]: Draft<T[K]>}
 	: T
 
-// Inline these in ts 3.7
-interface DraftMap<K, V> extends Map<Draft<K>, Draft<V>> {}
-
-// Inline these in ts 3.7
-interface DraftSet<V> extends Set<Draft<V>> {}
-
 /** Convert a mutable type into a readonly type */
 export type Immutable<T> = T extends AtomicObject
 	? T
-	: T extends Map<infer K, infer V> // Ideally, but wait for TS 3.7:    ? Omit<ImmutableMap<K, V>, "set" | "delete" | "clear">
-	? ImmutableMap<K, V>
-	: T extends Set<infer V> // Ideally, but wait for TS 3.7:    ? Omit<ImmutableSet<V>, "add" | "delete" | "clear">
-	? ImmutableSet<V>
+	: T extends ReadonlyMap<infer K, infer V> // Map extends ReadonlyMap
+	? ReadonlyMap<Immutable<K>, Immutable<V>>
+	: T extends ReadonlySet<infer V> // Set extends ReadonlySet
+	? ReadonlySet<Immutable<V>>
+	: T extends WeakReferences
+	? T
 	: T extends object
 	? {readonly [K in keyof T]: Immutable<T[K]>}
 	: T
-
-interface ImmutableMap<K, V> extends Map<Immutable<K>, Immutable<V>> {}
-
-interface ImmutableSet<V> extends Set<Immutable<V>> {}
 
 export interface Patch {
 	op: "replace" | "remove" | "add"


### PR DESCRIPTION
TypeScript provides the ReadonlySet and ReadonlyMap types which match
their normal counterparts but without any methods that mutate their data.
This change makes Immutable<Map> and Immutable<Set> map to those types
directly.

Worth noting that Map extends ReadonlyMap so we only need to check for
one to know what the resulting type is, the same goes for Set and
ReadonlySet.

This also removes the intermediate Set/Map types since TypeScript no
longer seems to need those (likely since TypeScript 3.7, see #448).