### PR TITLE
fix: patches when delete object property in array

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -648,6 +648,21 @@ describe("arrays - splice (shrink)", () => {
 	)
 })
 
+describe.only("arrays - delete", () => {
+	runPatchTest(
+		{
+			x: [
+				{a: 1, b: 2},
+				{c: 3, d: 4}
+			]
+		},
+		d => {
+			delete d.x[1].c
+		},
+		[{op: "remove", path: ["x", 1, "c"]}]
+	)
+})
+
 describe("sets - add - 1", () => {
 	runPatchTest(
 		new Set([1]),

--- a/src/es5.ts
+++ b/src/es5.ts
@@ -241,15 +241,22 @@ function markChangesRecursively(object: any) {
 				markChangedES5(state)
 			}
 		})
-	} else if (type === ProxyType.ES5Array && hasArrayChanges(state)) {
-		markChangedES5(state)
-		assigned.length = true
+	} else if (type === ProxyType.ES5Array) {
+		if (hasArrayChanges(state)) {
+			markChangedES5(state)
+			assigned.length = true
+		}
+
 		if (draft.length < base.length) {
 			for (let i = draft.length; i < base.length; i++) assigned[i] = false
 		} else {
 			for (let i = base.length; i < draft.length; i++) assigned[i] = true
 		}
-		for (let i = 0; i < draft.length; i++) {
+
+		// Minimum count is enough, the other parts has been processed.
+		const min = Math.min(draft.length, base.length)
+
+		for (let i = 0; i < min; i++) {
 			// Only untouched indices trigger recursion.
 			if (assigned[i] === undefined) markChangesRecursively(draft[i])
 		}


### PR DESCRIPTION
May be it's about two points:

1. The length is the same, `markChangesRecursively` is still necessary for un-processed array items. such as delete property in an object array, the `nextState` could be correct, but `patches` not works as expected.
2. The `delta` item has been process as `add`/`remove`. The remaining items count would be the `min` value.