### PR TITLE
fix: consistent naming for castDraft, fixup 2d27f33f6

### DIFF
--- a/__tests__/draft.ts
+++ b/__tests__/draft.ts
@@ -304,7 +304,7 @@ test("draft.ts", () => {
 	expect(true).toBe(true)
 })
 
-test("asDraft", () => {
+test("castDraft", () => {
 	type Todo = {readonly done: boolean}
 
 	type State = {
@@ -326,7 +326,7 @@ test("#505 original", () => {
 	})
 })
 
-test("asDraft preserves a value", () => {
+test("castDraft preserves a value", () => {
 	const x = {}
 	expect(castDraft(x)).toBe(x)
 })

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -93,7 +93,7 @@ This will generate the error:
 The type 'readonly Todo[]' is 'readonly' and cannot be assigned to the mutable type '{ done: boolean; }[]'
 ```
 
-The reason for this error is that we assign our read only, immutable array to our draft, which expects a mutable type, with methods like `.push` etc etc. As far as TS is concerned, those are not exposed from our original `State`. To hint TypeScript that we want to upcast the collection here to a mutable array for draft purposes, we can use the utility `asDraft`:
+The reason for this error is that we assign our read only, immutable array to our draft, which expects a mutable type, with methods like `.push` etc etc. As far as TS is concerned, those are not exposed from our original `State`. To hint TypeScript that we want to upcast the collection here to a mutable array for draft purposes, we can use the utility `castDraft`:
 
 `draft.finishedTodos = castDraft(state.unfinishedTodos)` will make the error disappear.
 


### PR DESCRIPTION
The function is called castDraft, the `asDraft` version seems to be a remnant of an earlier name. It’s only present in the documentation and the test titles, so this change is non-functional.