### PR TITLE
fix: change Full error url (issue#550)

### DIFF
--- a/__tests__/__prod_snapshots__/base.js.snap
+++ b/__tests__/__prod_snapshots__/base.js.snap
@@ -1,116 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`base functionality - es5 (autofreeze) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - es5 (autofreeze) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - es5 (autofreeze)(patch listener) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - es5 (no freeze) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) async recipe function works with rejected promises 1`] = `"[Immer] minified error nr: 3 {\\"a\\":0,\\"b\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - es5 (patch listener) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 1`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 2`] = `"[Immer] minified error nr: 3 {\\"a\\":1}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 3`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 4`] = `"[Immer] minified error nr: 3 [1]. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - es5 (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - es5 (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (autofreeze) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (autofreeze) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
@@ -130,25 +130,25 @@ exports[`base functionality - proxy (autofreeze) revokes the draft once produce 
 
 exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (autofreeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (autofreeze)(patch listener) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
@@ -168,25 +168,25 @@ exports[`base functionality - proxy (autofreeze)(patch listener) revokes the dra
 
 exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (no freeze) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (no freeze) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
@@ -206,25 +206,25 @@ exports[`base functionality - proxy (no freeze) revokes the draft once produce r
 
 exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (patch listener) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (patch listener) recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
 
@@ -244,17 +244,17 @@ exports[`base functionality - proxy (patch listener) revokes the draft once prod
 
 exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 {}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) throws on computed properties 1`] = `"[Immer] minified error nr: 1. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`base functionality - proxy (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`base functionality - proxy (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`complex nesting map / set / object modify deep object 1`] = `
 Object {

--- a/__tests__/__prod_snapshots__/curry.js.snap
+++ b/__tests__/__prod_snapshots__/curry.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`curry - es5 should check arguments 1`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - es5 should check arguments 1`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - es5 should check arguments 2`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - es5 should check arguments 2`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - es5 should check arguments 3`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - es5 should check arguments 3`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - es5 should check arguments 4`] = `"[Immer] minified error nr: 7. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - es5 should check arguments 4`] = `"[Immer] minified error nr: 7. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - proxy should check arguments 1`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - proxy should check arguments 1`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - proxy should check arguments 2`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - proxy should check arguments 2`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - proxy should check arguments 3`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - proxy should check arguments 3`] = `"[Immer] minified error nr: 6. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`curry - proxy should check arguments 4`] = `"[Immer] minified error nr: 7. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`curry - proxy should check arguments 4`] = `"[Immer] minified error nr: 7. Find the full error at: https://bit.ly/3cXEKWf"`;

--- a/__tests__/__prod_snapshots__/frozen.js.snap
+++ b/__tests__/__prod_snapshots__/frozen.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`auto freeze - es5 will freeze maps 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze maps 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - es5 will freeze maps 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze maps 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - es5 will freeze maps 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze maps 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - es5 will freeze sets 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze sets 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - es5 will freeze sets 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze sets 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - es5 will freeze sets 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - es5 will freeze sets 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze maps 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze maps 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze maps 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze maps 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze maps 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze maps 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze sets 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze sets 1`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze sets 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze sets 2`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`auto freeze - proxy will freeze sets 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`auto freeze - proxy will freeze sets 3`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;

--- a/__tests__/__prod_snapshots__/manual.js.snap
+++ b/__tests__/__prod_snapshots__/manual.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manual - es5 cannot modify after finish 1`] = `"[Immer] minified error nr: 3 {\\"a\\":2}. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`manual - es5 cannot modify after finish 1`] = `"[Immer] minified error nr: 3 {\\"a\\":2}. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`manual - es5 should check arguments 1`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`manual - es5 should check arguments 1`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`manual - es5 should check arguments 2`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`manual - es5 should check arguments 2`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`manual - es5 should check arguments 3`] = `"Cannot read property 'A' of undefined"`;
 
@@ -50,9 +50,9 @@ Array [
 
 exports[`manual - proxy cannot modify after finish 1`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`manual - proxy should check arguments 1`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`manual - proxy should check arguments 1`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`manual - proxy should check arguments 2`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`manual - proxy should check arguments 2`] = `"[Immer] minified error nr: 8. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`manual - proxy should check arguments 3`] = `"Cannot read property 'A' of undefined"`;
 

--- a/__tests__/__prod_snapshots__/patch.js.snap
+++ b/__tests__/__prod_snapshots__/patch.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`applyPatches throws when \`op\` is not "add", "replace", nor "remove" 1`] = `"[Immer] minified error nr: 17 copy. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`applyPatches throws when \`op\` is not "add", "replace", nor "remove" 1`] = `"[Immer] minified error nr: 17 copy. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`applyPatches throws when \`path\` cannot be resolved 1`] = `"[Immer] minified error nr: 15 a/b. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`applyPatches throws when \`path\` cannot be resolved 1`] = `"[Immer] minified error nr: 15 a/b. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`applyPatches throws when \`path\` cannot be resolved 2`] = `"[Immer] minified error nr: 15 a/b/c. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`applyPatches throws when \`path\` cannot be resolved 2`] = `"[Immer] minified error nr: 15 a/b/c. Find the full error at: https://bit.ly/3cXEKWf"`;

--- a/__tests__/__prod_snapshots__/plugins.js.snap
+++ b/__tests__/__prod_snapshots__/plugins.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ES5 plugins should throw if no proxies are available error when using ES5 1`] = `"[Immer] minified error nr: 19 ES5. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`ES5 plugins should throw if no proxies are available error when using ES5 1`] = `"[Immer] minified error nr: 19 ES5. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`error when using Maps 1`] = `"[Immer] minified error nr: 19 MapSet. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`error when using Maps 1`] = `"[Immer] minified error nr: 19 MapSet. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`error when using patches - 1 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`error when using patches - 1 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`error when using patches - 2 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`error when using patches - 2 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/3cXEKWf"`;
 
-exports[`error when using patches - 3 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`error when using patches - 3 1`] = `"[Immer] minified error nr: 19 Patches. Find the full error at: https://bit.ly/3cXEKWf"`;

--- a/__tests__/__prod_snapshots__/readme.js.snap
+++ b/__tests__/__prod_snapshots__/readme.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Producers can update Maps 4`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/38PiBHb"`;
+exports[`Producers can update Maps 4`] = `"[Immer] minified error nr: 2. Find the full error at: https://bit.ly/3cXEKWf"`;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -46,6 +46,6 @@ export function die(error: keyof typeof errors, ...args: any[]): never {
 	throw new Error(
 		`[Immer] minified error nr: ${error}${
 			args.length ? " " + args.join(",") : ""
-		}. Find the full error at: https://bit.ly/38PiBHb`
+		}. Find the full error at: https://bit.ly/3cXEKWf`
 	)
 }


### PR DESCRIPTION
As [issue#550](https://github.com/immerjs/immer/issues/550) said

[https://bit.ly/38PiBHb](https://bit.ly/38PiBHb) is not valid any more.

This PR just change url older to new one.

The new url origin url is `https://github.com/immerjs/immer/blob/master/src/utils/errors.ts`.
Shorten url is [https://bit.ly/3cXEKWf](https://bit.ly/3cXEKWf)

That's it.