### PR TITLE
Using a immerable class with a getter without a setter

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -2090,6 +2090,46 @@ function testObjectTypes(produce) {
 			})
 		})
 	}
+
+	describe("class with getters", () => {
+		class State {
+			[immerable] = true
+			_bar = {baz: 1}
+			foo
+			get bar() {
+				return this._bar
+			}
+			syncFoo() {
+				this.foo = this.bar.baz
+			}
+		}
+		const state = new State()
+
+		it("should use a method to assing a field using a getter that return a non primitive object", () => {
+			const newState = produce(state, draft => {
+				draft.syncFoo()
+			})
+			expect(newState.foo).toEqual(1)
+		})
+	})
+
+	describe("class with setters", () => {
+		class State {
+			[immerable] = true
+			_bar = 0
+			set bar(x) {
+				this._bar = x
+			}
+		}
+		const state = new State()
+
+		it("should define a field with a setter", () => {
+			const newState3 = produce(state, d => {
+				d.bar = 1
+			})
+			expect(newState3._bar).toEqual(1)
+		})
+	})
 }
 
 function testLiteralTypes(produce) {

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -2108,8 +2108,11 @@ function testObjectTypes(produce) {
 		it("should use a method to assing a field using a getter that return a non primitive object", () => {
 			const newState = produce(state, draft => {
 				draft.syncFoo()
+				expect(draft.bar).toEqual({baz: 1})
 			})
 			expect(newState.foo).toEqual(1)
+			expect(newState.bar).toEqual({baz: 1})
+			expect(state.bar).toEqual({baz: 1})
 		})
 	})
 
@@ -2117,6 +2120,9 @@ function testObjectTypes(produce) {
 		class State {
 			[immerable] = true
 			_bar = 0
+			get bar() {
+				return this._bar
+			}
 			set bar(x) {
 				this._bar = x
 			}
@@ -2126,8 +2132,12 @@ function testObjectTypes(produce) {
 		it("should define a field with a setter", () => {
 			const newState3 = produce(state, d => {
 				d.bar = 1
+				expect(d._bar).toEqual(1)
 			})
 			expect(newState3._bar).toEqual(1)
+			expect(newState3.bar).toEqual(1)
+			expect(state._bar).toEqual(0)
+			expect(state.bar).toEqual(0)
 		})
 	})
 }

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -239,8 +239,14 @@ export function markChangedProxy(state: ImmerState) {
 		) {
 			const copy = (state.copy_ = shallowCopy(state.base_))
 			each(state.drafts_!, (key, value) => {
-				// @ts-ignore
-				copy[key] = value
+				const descProto = Object.getOwnPropertyDescriptor(
+					Object.getPrototypeOf(copy),
+					key
+				)
+				if (!(descProto && descProto.get && !descProto.set)) {
+					// @ts-ignore
+					copy[key] = value
+				}
 			})
 			state.drafts_ = undefined
 		}


### PR DESCRIPTION
In an immerable class with a getter without the corresponding setter, assigning a value to any field using the getter value within a class method causes the following error:

> #TypeError#
> Cannot set property bar of #<Obj> which has only a getter

It only happens with non-primitive getter values and with `setUseProxies(true)`
It can be fixed in userland creating an empty setter (`set prop(v) {}`) 
This PR makes the markChangedProxy function to skip the assignment `copy[key]=value` when there is a getter without a setter.

It fixes https://github.com/immerjs/immer/issues/439 and replaces https://github.com/immerjs/immer/pull/438

#### Links to Repro (updated to immer 6.0.2)
https://codesandbox.io/s/small-rain-inotu
https://codesandbox.io/s/useimmer-tic-tac-ci6qq

#### To Reproduce 
```js
import { produce, immerable } from "immer";
class Obj {
  [immerable] = true;
  foo = 0;
  _bar = { baz: 1 };
  get bar() {return this._bar}
  syncFoo() {
    return produce(this, state => {
      state.foo = state.bar.baz;
    });
  }
}
const obj = new Obj();
const obj2 = obj.syncFoo();
```

