### PR TITLE
Ensure values in patches are never a draft

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -1016,7 +1016,7 @@ test("#521", () => {
 	)
 })
 
-test.only("#559 patches works in a nested reducer with proxies", () => {
+test("#559 patches works in a nested reducer with proxies", () => {
 	setUseProxies(true)
 
 	const state = {


### PR DESCRIPTION
When you are generating patches in a nested reducer, patches values can be a Proxy. They need to be cloned before stored into the patch otherwise the patch cannot be applied as the proxy will be revoked.

I added a single test for this and ensured it was failing before my patch. If you want other tests to be added, please tell me what you would like.

Fixes #559