### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -9,6 +9,10 @@
 // site configuration options.
 
 const siteConfig = {
+    	algolia: {
+     		apiKey: '3570c86ca04edefca80e124a50e2bed9',
+		indexName: 'immerjs',
+	},
 	title: "Immer", // Title for your website.
 	tagline: "Create the next immutable state by mutating the current one",
 	url: "https://immerjs.github.io", // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.