### PR TITLE
Fix #594 Flow type for `Base` too limiting

### DIFF
--- a/__tests__/flow/flow.js.flow
+++ b/__tests__/flow/flow.js.flow
@@ -100,6 +100,34 @@ type State = {| user: {| age: number |} |}
     }))
 }
 
+// #594 Allow undefined currentState with normal produce
+type Foo = {| a: boolean |} | void
+function func(foo: Foo) {
+    let bar = produce(foo, (draft) => {
+        // $ExpectError
+        draft.a = true
+        if (!draft) return
+        draft.a = true
+        // $ExpectError
+        draft.b = true
+    });
+    (bar: Foo)
+}
+
+// #594 Allow undefined currentState with curried produce and no initial state
+function func(foo: Foo) {
+    const f = produce(draft => {
+        // $ExpectError
+        draft.a = true
+        if (!draft) return
+        draft.a = true
+        // $ExpectError
+        draft.b = true
+    })
+    const bar = f(foo);
+    (bar: Foo)
+}
+
 {
     // $ExpectError
     produce2({x: 3})

--- a/__tests__/flow/flow.js.flow
+++ b/__tests__/flow/flow.js.flow
@@ -1,5 +1,6 @@
 // @flow
 import produce, {
+    enableMapSet,
     setAutoFreeze,
     setUseProxies,
     produce as produce2,
@@ -8,6 +9,7 @@ import produce, {
     original
 } from "../../dist/index.js.flow"
 
+enableMapSet()
 setAutoFreeze(true)
 setUseProxies(true)
 
@@ -173,4 +175,42 @@ function func(foo: Foo) {
             const c: string = a[0]
         }
     })
+}
+
+function testMap(state: Map<number, string>) {
+    // normal
+    state = produce(state, draft => {
+        if (draft.has(1)) {
+            return
+        }
+        // $ExpectError
+        draft.set(1, 2)
+        draft.set(1, "tada")
+    });
+    // curried, no initial state
+    const f1 = produce(draft=> { draft.set(2, "ok") })
+    state = f1(state)
+    // curried, with initial state
+    const f2 = produce(draft=> { draft.set(2, "ok") }, state)
+    state = f2(state)
+    state = f2(undefined)
+}
+
+function testSet(state: Set<number>) {
+    // normal
+    state = produce(state, draft => {
+        if (draft.has(1)) {
+            return
+        }
+        // $ExpectError
+        draft.add("me")
+        draft.add(100)
+    })
+    // curried, no initial state
+    const f1 = produce(draft => { draft.add(draft.size) })
+    state = f1(state)
+    // curried, with initial state
+    const f2 = produce(draft => { draft.add(draft.size) }, state)
+    state = f2(state)
+    state = f2(undefined)
 }

--- a/src/types/index.js.flow
+++ b/src/types/index.js.flow
@@ -8,7 +8,7 @@ export interface Patch {
 
 export type PatchListener = (patches: Patch[], inversePatches: Patch[]) => void
 
-type Base = {...} | Array<any> | Map<any> | Set<any> | string | number | null;
+type Base = {...} | Array<any> | string | number | null;
 interface IProduce {
     /**
      * Immer takes a state, and runs a function against it.

--- a/src/types/index.js.flow
+++ b/src/types/index.js.flow
@@ -8,7 +8,7 @@ export interface Patch {
 
 export type PatchListener = (patches: Patch[], inversePatches: Patch[]) => void
 
-type Base = {...} | Array<any> | Map<any> | Set<any>;
+type Base = {...} | Array<any> | Map<any> | Set<any> | string | number | null;
 interface IProduce {
     /**
      * Immer takes a state, and runs a function against it.
@@ -23,7 +23,7 @@ interface IProduce {
      * @param initialState - if a curried function is created and this argument was given, it will be used as fallback if the curried function is called with a state of undefined
      * @returns The next state: a new state, or the current state if nothing was modified
      */
-    <S: Base>(
+    <S: Base | void>(
         currentState: S,
         recipe: (draftState: S) => S | void,
         patchListener?: PatchListener
@@ -34,7 +34,7 @@ interface IProduce {
         initialState: S
     ): (currentState: S | void, a: A, b: B, c: C, ...extraArgs: any[]) => S;
     // curried invocations without inital state
-    <S: Base, A = void, B = void, C = void>(
+    <S: Base | void, A = void, B = void, C = void>(
         recipe: (draftState: S, a: A, b: B, c: C, ...extraArgs: any[]) => S | void
     ): (currentState: S, a: A, b: B, c: C, ...extraArgs: any[]) => S;
 }


### PR DESCRIPTION
Allow currentState to be string, number & null as well as void (undefined) in the case of normal produce and curried produce with no initial state.