### PR TITLE
fix: remove error throwing when use setUseProxies(false)

### DIFF
--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -177,9 +177,6 @@ export class Immer implements ProducersFns {
 	 * By default, feature detection is used, so calling this is rarely necessary.
 	 */
 	setUseProxies(value: boolean) {
-		if (!hasProxies) {
-			die(20)
-		}
 		this.useProxies_ = value
 	}
 


### PR DESCRIPTION
hello, when I use immer on the Android4.3 which does not support Proxy, 
```js
setUseProxies(false)
```
but got an error.

I have to use as bellow
```js
const hasProxies =
	typeof Proxy !== "undefined" &&
	typeof Proxy.revocable !== "undefined" &&
	typeof Reflect !== "undefined"
hasProxies && setUseProxies(false)
```

ps: for some reason, I have to disable Proxy anyway, for I have code like this
```js
Object.defineProperty(draft, desc);
```
if enable proxy, this will throw error