### PR TITLE
fix: use Array.prototype.slice() for copying arrays. Fixes #650

### DIFF
--- a/__tests__/regressions.js
+++ b/__tests__/regressions.js
@@ -140,5 +140,23 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 			})
 			expect(result).toEqual(new Set())
 		})
+
+		test("#650 - changes with overridden arr.slice() fail", () => {
+			const data = {
+				foo: [
+					{
+						isActive: false
+					}
+				]
+			}
+			// That's roughly what seamless-immutable does
+			data.foo.slice = (...args) =>
+				Object.freeze(Array.prototype.slice.call(data.foo, ...args))
+
+			const newData = produce(data, draft => {
+				draft.foo[0].isActive = true
+			})
+			expect(newData.foo[0].isActive).toBe(true)
+		})
 	})
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -154,7 +154,7 @@ export function latest(state: ImmerState): any {
 
 /*#__PURE__*/
 export function shallowCopy(base: any) {
-	if (Array.isArray(base)) return base.slice()
+	if (Array.isArray(base)) return Array.prototype.slice.call(base)
 	const descriptors = getOwnPropertyDescriptors(base)
 	delete descriptors[DRAFT_STATE as any]
 	let keys = ownKeys(descriptors)


### PR DESCRIPTION
This small PR addresses an error that occurs when working with immer and seamless-immutable in one project. See #650.