### PR TITLE
skip ReadonlyMap and ReadonlySet types when not available

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -18,16 +18,33 @@ type AtomicObject =
 	| String
 
 /**
+ * If the lib "ES2105.collections" is not included in tsconfig.json,
+ * types like ReadonlyArray, WeakMap etc. fall back to `any` (specified nowhere)
+ * or `{}` (from the node types), in both cases entering an infite recursion in
+ * pattern matching type mappings
+ * This type can be used to cast these types to `void` in these cases.
+ */
+export type IfAvailable<T, Fallback = void> =
+	// fallback if any
+	true | false extends (T extends never
+	? true
+	: false)
+		? Fallback // fallback if empty type
+		: keyof T extends never
+		? Fallback // original type
+		: T
+
+/**
  * These should also never be mapped but must be tested after regular Map and
  * Set
  */
-type WeakReferences = WeakMap<any, any> | WeakSet<any>
+type WeakReferences = IfAvailable<WeakMap<any, any>> | IfAvailable<WeakSet<any>>
 
 export type Draft<T> = T extends AtomicObject
 	? T
-	: T extends ReadonlyMap<infer K, infer V> // Map extends ReadonlyMap
+	: T extends IfAvailable<ReadonlyMap<infer K, infer V>> // Map extends ReadonlyMap
 	? Map<Draft<K>, Draft<V>>
-	: T extends ReadonlySet<infer V> // Set extends ReadonlySet
+	: T extends IfAvailable<ReadonlySet<infer V>> // Set extends ReadonlySet
 	? Set<Draft<V>>
 	: T extends WeakReferences
 	? T
@@ -38,9 +55,9 @@ export type Draft<T> = T extends AtomicObject
 /** Convert a mutable type into a readonly type */
 export type Immutable<T> = T extends AtomicObject
 	? T
-	: T extends ReadonlyMap<infer K, infer V> // Map extends ReadonlyMap
+	: T extends IfAvailable<ReadonlyMap<infer K, infer V>> // Map extends ReadonlyMap
 	? ReadonlyMap<Immutable<K>, Immutable<V>>
-	: T extends ReadonlySet<infer V> // Set extends ReadonlySet
+	: T extends IfAvailable<ReadonlySet<infer V>> // Set extends ReadonlySet
 	? ReadonlySet<Immutable<V>>
 	: T extends WeakReferences
 	? T


### PR DESCRIPTION
This should fix #624 .

Instead of my initial idea of providing interfaces with the same shape as `ReadonlyMap`, `ReadonlySet`, `WeakMap` and `WeakSet` (which would also have worked, but probably required a lot more duplicate code), this is now following a different approach:

It checks if the types are `any` (which they would fall back to if they were not present) or a keyless interface (which at least `ReadonlyMap` and `ReadonlySet` would be if the `node` types are installed), in which case they fall back to `void`, which does not trigger the conditional.

The check for `any` is done by `true | false extends (T extends never ? true : false)` -  every other type will either be `true` or `false`, but since `any` takes both paths, it becomes `true | false`.

The check for the empty interface is done by `keyof T extends never` - everything except the empty interface has some keys, including primitives like `string` and `number` (which will have the keys of their prototype).