### PR TITLE
Abuse typescript generics to show the error message for calls to `die`

### DIFF
--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -57,7 +57,7 @@ export function processResult(result: any, scope: ImmerScope) {
 }
 
 function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
-	// Don't recurse in tho recursive data structures
+	// Don't recurse into recursive data structures
 	if (isFrozen(value)) return value
 
 	const state: ImmerState = value[DRAFT_STATE]

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,8 +1,9 @@
+type S = string & {}
 const errors = {
 	0: "Illegal state",
 	1: "Immer drafts cannot have computed properties",
 	2: "This object has been frozen and should not be mutated",
-	3(data: any) {
+	3(data: any): "Cannot use a proxy that has been revoked" | S {
 		return (
 			"Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? " +
 			data
@@ -19,32 +20,42 @@ const errors = {
 	12: "Object.setPrototypeOf() cannot be used on an Immer draft",
 	13: "Immer only supports deleting array indices",
 	14: "Immer only supports setting array indices and the 'length' property",
-	15(path: string) {
+	15(path: string): "Cannot apply patch, path doesn't resolve" | S {
 		return "Cannot apply patch, path doesn't resolve: " + path
 	},
 	16: 'Sets cannot have "replace" patches.',
-	17(op: string) {
+	17(op: string): "Unsupported patch operation" | S {
 		return "Unsupported patch operation: " + op
 	},
-	18(plugin: string) {
+	18(plugin: string): "The plugin for not loaded" | S {
 		return `The plugin for '${plugin}' has not been loaded into Immer. To enable the plugin, import and call \`enable${plugin}()\` when initializing your application.`
 	},
 	19: "plugin not loaded",
 	20: "Cannot use proxies if Proxy, Proxy.revocable or Reflect are not available",
-	21(thing: string) {
+	21(
+		thing: string
+	): "produce can only be called on things that are draftable" | S {
 		return `produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '${thing}'`
 	},
-	22(thing: string) {
+	22(thing: string): "'current' expects a draft" | S {
 		return `'current' expects a draft, got: ${thing}`
 	},
-	23(thing: string) {
+	23(thing: string): "'original' expects a draft" | S {
 		return `'original' expects a draft, got: ${thing}`
 	}
 } as const
 
-export function die(error: keyof typeof errors, ...args: any[]): never {
+type ErrMsg<E extends string | ((...args: any[]) => string)> = E extends (
+	...args: any[]
+) => infer S
+	? S
+	: E
+export function die<
+	N extends keyof typeof errors,
+	E = ErrMsg<typeof errors[N]>
+>(error: N, ...args: any[]): never {
 	if (__DEV__) {
-		const e = errors[error]
+		const e = errors[error as keyof typeof errors]
 		const msg = !e
 			? "unknown error nr: " + error
 			: typeof e === "function"


### PR DESCRIPTION
`doc: add generic to die to show what the error number means`

Mostly, I did this to help me understand the error codes quicker as i'm looking through how immer works.
 
![Screen Shot 2020-09-11 at 4 01 45 PM](https://user-images.githubusercontent.com/760204/92979844-cea58c80-f448-11ea-874c-801c3f7f7e53.png)
![Screen Shot 2020-09-11 at 4 02 42 PM](https://user-images.githubusercontent.com/760204/92979847-cfd6b980-f448-11ea-8c1e-a6145272f5e5.png)

Feel free to close if you don't want this in your codebase.