### PR TITLE
New tests (one currently failing): Non-immerable instances

### DIFF
--- a/__tests__/__snapshots__/base.js.snap
+++ b/__tests__/__snapshots__/base.js.snap
@@ -22,6 +22,8 @@ exports[`base functionality - es5 (autofreeze) set drafts revokes sets 1`] = `"[
 
 exports[`base functionality - es5 (autofreeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
+exports[`base functionality - es5 (autofreeze) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
+
 exports[`base functionality - es5 (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
 exports[`base functionality - es5 (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
@@ -45,6 +47,8 @@ exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft
 exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
 exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - es5 (autofreeze)(patch listener) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
 
 exports[`base functionality - es5 (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
@@ -70,6 +74,8 @@ exports[`base functionality - es5 (no freeze) set drafts revokes sets 1`] = `"[I
 
 exports[`base functionality - es5 (no freeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
+exports[`base functionality - es5 (no freeze) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
+
 exports[`base functionality - es5 (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
 exports[`base functionality - es5 (patch listener) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
@@ -93,6 +99,8 @@ exports[`base functionality - es5 (patch listener) revokes the draft once produc
 exports[`base functionality - es5 (patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
 exports[`base functionality - es5 (patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - es5 (patch listener) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
 
 exports[`base functionality - es5 (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
@@ -129,6 +137,8 @@ exports[`base functionality - proxy (autofreeze) revokes the draft once produce 
 exports[`base functionality - proxy (autofreeze) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
 exports[`base functionality - proxy (autofreeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy (autofreeze) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
 
 exports[`base functionality - proxy (autofreeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
 
@@ -170,6 +180,8 @@ exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revo
 
 exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
+exports[`base functionality - proxy (autofreeze)(patch listener) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
+
 exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
 
 exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
@@ -210,6 +222,8 @@ exports[`base functionality - proxy (no freeze) set drafts revokes sets 1`] = `"
 
 exports[`base functionality - proxy (no freeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
+exports[`base functionality - proxy (no freeze) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
+
 exports[`base functionality - proxy (no freeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
 
 exports[`base functionality - proxy (no freeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
@@ -249,6 +263,8 @@ exports[`base functionality - proxy (patch listener) revokes the draft once prod
 exports[`base functionality - proxy (patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
 exports[`base functionality - proxy (patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy (patch listener) throws on non-immerable instance 1`] = `"[Immer] produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '[object Object]'"`;
 
 exports[`base functionality - proxy (patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
 

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -883,6 +883,20 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 			})
 		})
 
+		it("throws on non-immerable instance", () => {
+			const Pet = class {
+				constructor(name) {
+					this.name = name
+				}
+			}
+			const baseState = new Pet("Rover")
+			expect(() => {
+				produce(baseState, draft => {
+					draft.name = "Rex"
+				})
+			}).toThrowErrorMatchingSnapshot()
+		})
+
 		it("supports `immerable` symbol on constructor", () => {
 			class One {}
 			One[immerable] = true

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -897,6 +897,20 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 			}).toThrowErrorMatchingSnapshot()
 		})
 
+		it("throws on non-immerable class-instance property of plain object", () => {
+			const Pet = class {
+				constructor(name) {
+					this.name = name
+				}
+			}
+			const baseState = {pet: new Pet("Rover")}
+			expect(() => {
+				produce(baseState, draft => {
+					draft.pet.name = "Rex"
+				})
+			}).toThrowErrorMatchingSnapshot()
+		})
+
 		it("supports `immerable` symbol on constructor", () => {
 			class One {}
 			One[immerable] = true


### PR DESCRIPTION
I recently got tripped up by Immer silently misbehaving when the top-level `baseState` was a plain object, but within it was a class instance.  Had I read the manual more carefully, I would have been aware of the `immerable` requirement, but nonetheless it would have been helpful if Immer had thrown a noisy error.  This PR adds two tests, both testing that an error is thrown if you try to use Immer with an instance of a non-`immerable` class.  One of the tests fails, as no error is thrown for
```javascript
const Pet = class { constructor(name) { this.name = name } }
const baseState = {pet: new Pet("Rover")}
produce(baseState, draft => { draft.pet.name = "Rex" })
```
Would it be possible to have Immer throw its _[Immer] produce can only be called on things that are draftable..._ error in this case?  I'm afraid I'm not familiar enough with the internals of Immer to propose a fix, but hopefully these tests will be useful.

Thanks!