### PR TITLE
Fix Clock time getter in complex objects docs

### DIFF
--- a/docs/complex-objects.md
+++ b/docs/complex-objects.md
@@ -37,7 +37,7 @@ class Clock {
 	}
 
 	get time() {
-		return `${this.hour}:${minute}`
+		return `${this.hour}:${this.minute}`
 	}
 
 	tick() {


### PR DESCRIPTION
The time getter is trying to accessing `this.minutes`, but it's missing `this.`!
```ts
get time() {
	return `${this.hour}:${minute}`
}
```