### PR TITLE
Use UTC date string in tests to be timezone independent

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -1131,7 +1131,7 @@ test("#676 patching Date objects", () => {
 	}
 
 	const [nextState, patches] = produceWithPatches({}, function(draft) {
-		draft.date = new Date(2020, 10, 10, 8, 8, 8, 3)
+		draft.date = new Date("2020-11-10T08:08:08.003Z")
 		draft.test = new Test()
 	})
 
@@ -1145,5 +1145,5 @@ test("#676 patching Date objects", () => {
 	expect(rebuilt.date.toJSON()).toMatchInlineSnapshot(
 		`"2020-11-10T08:08:08.003Z"`
 	)
-	expect(rebuilt.date).toEqual(new Date(2020, 10, 10, 8, 8, 8, 3))
+	expect(rebuilt.date).toEqual(new Date("2020-11-10T08:08:08.003Z"))
 })


### PR DESCRIPTION
I noticed that one of the tests failed when run locally (I am in the CET timezone ATM), because the stringified date did not match the snapshot (was 1 hour off):

![image](https://user-images.githubusercontent.com/889383/99875305-bc855e80-2bee-11eb-82f0-93f10de478d9.png)

This probably stems from the fact that the `Date` constructor parses the values as though they were in the local timezone (CET +1 for me). Going back to UTC (which is what `toJSON` produces) subtracts that 1 hour, which makes it show 7:08:08 instead of 8:08:08.

I reckon using a UTC string could solve the problem. Another alternative would be using a constructor with a UNIX timestamp, but I reckon the current solution is more readable.

Fixes #712 