### PR TITLE
chore: fix Buffer deprecation warning in test

### DIFF
--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -23,7 +23,7 @@ function runTests(name, useProxies) {
 
 		it("should check arguments", () => {
 			expect(() => createDraft(3)).toThrowErrorMatchingSnapshot()
-			const buf = new Buffer([])
+			const buf = Buffer.from([])
 			expect(() => createDraft(buf)).toThrowErrorMatchingSnapshot()
 			expect(() => finishDraft({})).toThrowErrorMatchingSnapshot()
 		})


### PR DESCRIPTION
There was a deprecation warning because `new Buffer([])` was used in one of the tests.

```
(node:25795) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS  __tests__/manual.js
```

![image](https://user-images.githubusercontent.com/889383/99875592-26066c80-2bf1-11eb-9634-650891a41e6c.png)
