### PR TITLE
feature: Support copy-on-write in TypedArrays

### DIFF
--- a/__tests__/__snapshots__/patch.js.snap
+++ b/__tests__/__snapshots__/patch.js.snap
@@ -5,3 +5,9 @@ exports[`applyPatches throws when \`op\` is not "add", "replace", nor "remove" 1
 exports[`applyPatches throws when \`path\` cannot be resolved 1`] = `"[Immer] Cannot apply patch, path doesn't resolve: a/b"`;
 
 exports[`applyPatches throws when \`path\` cannot be resolved 2`] = `"[Immer] Cannot apply patch, path doesn't resolve: a/b/c"`;
+
+exports[`typed arrays - patch throws for all \`op\`s 1`] = `"[Immer] TypedArrays cannot have patches."`;
+
+exports[`typed arrays - patch throws for all \`op\`s 2`] = `"[Immer] TypedArrays cannot have patches."`;
+
+exports[`typed arrays - patch throws for all \`op\`s 3`] = `"[Immer] TypedArrays cannot have patches."`;

--- a/__tests__/draft.ts
+++ b/__tests__/draft.ts
@@ -211,6 +211,13 @@ test("draft.ts", () => {
 		assert(toDraft(val), draft)
 	}
 
+	// Uint16Array
+	{
+		let val: Uint16Array = _
+		assert(toDraft(val), val)
+		assert(fromDraft(toDraft(val)), val)
+	}
+
 	// Promise object
 	{
 		let val: Promise<any> = _

--- a/__tests__/immutable.ts
+++ b/__tests__/immutable.ts
@@ -82,6 +82,12 @@ test("types are ok", () => {
 		assert(val, _ as ReadonlySet<string>)
 	}
 
+	// Uint16Array
+	{
+		let val = _ as Immutable<Uint16Array>
+		assert(val, _ as Uint16Array)
+	}
+
 	// Already immutable Set
 	{
 		let val = _ as Immutable<ReadonlySet<string>>

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -786,6 +786,23 @@ describe("sets - mutate - 1", () => {
 	)
 })
 
+describe("typed arrays - patch", () => {
+	it("throws for all `op`s", () => {
+		const arr = new Uint16Array(1)
+		expect(() =>
+			applyPatches(arr, [{op: "add", path: [0], value: 1}])
+		).toThrowErrorMatchingSnapshot()
+
+		expect(() =>
+			applyPatches(arr, [{op: "remove", path: [0]}])
+		).toThrowErrorMatchingSnapshot()
+
+		expect(() =>
+			applyPatches(arr, [{op: "replace", path: [0], value: 1}])
+		).toThrowErrorMatchingSnapshot()
+	})
+})
+
 describe("arrays - splice should should result in remove op.", () => {
 	// These patches were more optimal pre immer 7, but not always correct
 	runPatchTest(

--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -801,6 +801,17 @@ describe("typed arrays - patch", () => {
 			applyPatches(arr, [{op: "replace", path: [0], value: 1}])
 		).toThrowErrorMatchingSnapshot()
 	})
+
+	it("should be empty", () => {
+		const arr = new Uint16Array(1)
+
+		const [_, patches, inversePatches] = produceWithPatches(arr, draft => {
+			draft[0] = 5
+		})
+
+		expect(patches).toEqual([])
+		expect(inversePatches).toEqual([])
+	})
 })
 
 describe("arrays - splice should should result in remove op.", () => {

--- a/__tests__/typed-arrays.js
+++ b/__tests__/typed-arrays.js
@@ -72,7 +72,28 @@ describe("typed arrays", () => {
 		})
 	})
 
-	it.todo("should return correct patches")
+	it("should return correct patches", () => {
+		const baseState = new Uint16Array(4)
+
+		const [nextState, patches] = produceWithPatches(baseState, draftState => {
+			draftState[0] = 50
+			draftState[1] = 20
+		})
+
+		expect(nextState).toEqual(new Uint16Array([50, 20, 0, 0]))
+		expect(patches).toEqual([
+			{
+				op: "replace",
+				path: [0],
+				value: 50
+			},
+			{
+				op: "replace",
+				path: [1],
+				value: 20
+			}
+		])
+	})
 
 	it("should work when using a slice of an ArrayBuffer", () => {
 		const arrayBuffer = new ArrayBuffer(8)

--- a/__tests__/typed-arrays.js
+++ b/__tests__/typed-arrays.js
@@ -140,15 +140,46 @@ describe("typed arrays", () => {
 		})
 	})
 
-	it("should have a draft that behaves like a TypedArray", () => {
+	it("should have a draft that has the same prototype as the target", () => {
 		expect.hasAssertions()
 
 		const baseState = new Uint16Array(1)
 
 		produce(baseState, draftState => {
-			console.log(draftState)
-			expect(ArrayBuffer.isView(draftState)).toBe(true)
 			expect(draftState instanceof Uint16Array).toBe(true)
 		})
+	})
+
+	it("should not be an ArrayBuffer view due to spec behavior", () => {
+		expect.hasAssertions()
+
+		const baseState = new Uint16Array(1)
+
+		produce(baseState, draftState => {
+			// Proxies for TypedArrays do not pass `ArrayBuffer.isView`
+			expect(ArrayBuffer.isView(draftState)).toBe(false)
+		})
+	})
+
+	it("should have a draft with the same own properties", () => {
+		expect.hasAssertions()
+
+		const baseState = new Uint16Array(5)
+
+		produce(baseState, draftState => {
+			expect(Object.keys(draftState)).toEqual(Object.keys(baseState))
+		})
+	})
+
+	it("should behave correctly with nested produce calls", () => {
+		const baseState = new Uint16Array(3)
+
+		const nextState = produce(baseState, draftState => {
+			return produce(draftState, secondLevelDraft => {
+				secondLevelDraft[1] = 2
+			})
+		})
+
+		expect(nextState).toEqual(new Uint16Array([0, 2, 0]))
 	})
 })

--- a/__tests__/typed-arrays.js
+++ b/__tests__/typed-arrays.js
@@ -139,4 +139,16 @@ describe("typed arrays", () => {
 			expect(draftState.length).toBe(baseState.length)
 		})
 	})
+
+	it("should have a draft that behaves like a TypedArray", () => {
+		expect.hasAssertions()
+
+		const baseState = new Uint16Array(1)
+
+		produce(baseState, draftState => {
+			console.log(draftState)
+			expect(ArrayBuffer.isView(draftState)).toBe(true)
+			expect(draftState instanceof Uint16Array).toBe(true)
+		})
+	})
 })

--- a/__tests__/typed-arrays.js
+++ b/__tests__/typed-arrays.js
@@ -1,0 +1,132 @@
+import produce, {enableAllPlugins, produceWithPatches} from "../src/immer"
+
+describe("typed arrays", () => {
+	beforeAll(() => {
+		enableAllPlugins()
+	})
+
+	it("should create a copy on write", () => {
+		const baseState = {
+			data: new Uint16Array(3)
+		}
+
+		const nextState = produce(baseState, draftState => {
+			draftState.data.fill(1)
+			draftState.data[1] = 5
+		})
+
+		expect(nextState).toEqual({
+			data: new Uint16Array([1, 5, 1])
+		})
+		expect(baseState.data).toEqual(new Uint16Array(3))
+	})
+
+	it("should create one copy of the same underlying ArrayBuffer with multiple views", () => {
+		const arrayBuffer = new ArrayBuffer(8)
+		const baseState = {
+			uint16: new Uint16Array(arrayBuffer),
+			float32: new Float32Array(arrayBuffer)
+		}
+
+		const nextState = produce(baseState, draftState => {
+			draftState.uint16[0] = 1
+			draftState.uint16[1] = 2
+			draftState.float32[1] = 3
+		})
+
+		expect(nextState.uint16.buffer).toBe(nextState.float32.buffer)
+		expect(nextState.uint16.slice(0, 2)).toEqual(new Uint16Array([1, 2]))
+		expect(nextState.float32.slice(1)).toEqual(new Float32Array([3]))
+		expect(new Uint8Array(arrayBuffer)).toEqual(new Uint8Array(8))
+	})
+
+	it("should not copy arrays when performing non-mutating operations", () => {
+		const baseState = {
+			data: new Uint16Array([1, 2]),
+			result: undefined
+		}
+
+		const nextState = produce(baseState, draftState => {
+			draftState.result = draftState.data.map(x => x + 1)
+		})
+
+		expect(nextState).toEqual({
+			data: new Uint16Array([1, 2]),
+			result: new Uint16Array([2, 3])
+		})
+		expect(nextState.data).toBe(baseState.data)
+	})
+
+	it("should use previously modified values when reading from draft", () => {
+		const baseState = {
+			data: new Uint16Array(2)
+		}
+
+		const nextState = produce(baseState, draftState => {
+			draftState.data[0] = 1
+			draftState.data[1] = draftState.data[0]
+		})
+
+		expect(nextState).toEqual({
+			data: new Uint16Array([1, 1])
+		})
+	})
+
+	it.todo("should return correct patches")
+
+	it("should work when using a slice of an ArrayBuffer", () => {
+		const arrayBuffer = new ArrayBuffer(8)
+		const baseState = {
+			data: new Uint16Array(arrayBuffer, 2, 2)
+		}
+
+		const nextState = produce(baseState, draftState => {
+			draftState.data[0] = 1
+			draftState.data[1] = 2
+		})
+
+		expect(nextState).toEqual({
+			data: new Uint16Array([1, 2])
+		})
+		expect(new Uint8Array(arrayBuffer)).toEqual(new Uint8Array(8))
+	})
+
+	it("should allow modifying the internal ArrayBuffer without copying", () => {
+		const baseState = {
+			data: new Uint16Array(1)
+		}
+
+		const nextState = produce(baseState, draftState => {
+			new Uint16Array(draftState.data.buffer)[0] = 50
+		})
+
+		expect(nextState).toEqual({
+			data: new Uint16Array([50])
+		})
+		expect(new Uint8Array(baseState.data)).toEqual(new Uint8Array([50]))
+	})
+
+	it("should allow passing a typed array immediately to produce", () => {
+		const baseState = new Uint16Array(1)
+
+		const nextState = produce(baseState, draftState => {
+			draftState[0] = 50
+		})
+
+		expect(nextState).toEqual(new Uint16Array([50]))
+		expect(baseState).toEqual(new Uint16Array([0]))
+	})
+
+	it("should contain correct TypedArray properties in the draft", () => {
+		expect.hasAssertions()
+		const baseState = new Uint16Array(1)
+
+		produce(baseState, draftState => {
+			expect(draftState.BYTES_PER_ELEMENT).toBe(Uint16Array.BYTES_PER_ELEMENT)
+			expect(draftState.buffer).toBe(baseState.buffer)
+			expect(draftState.byteLength).toBe(baseState.byteLength)
+			expect(draftState.byteOffset).toBe(baseState.byteOffset)
+			expect(draftState.length).toBe(baseState.length)
+		})
+	})
+})

--- a/__tests__/typed-arrays.js
+++ b/__tests__/typed-arrays.js
@@ -72,7 +72,7 @@ describe("typed arrays", () => {
 		})
 	})
 
-	it("should return correct patches", () => {
+	it("should return empty patches", () => {
 		const baseState = new Uint16Array(4)
 
 		const [nextState, patches] = produceWithPatches(baseState, draftState => {
@@ -81,18 +81,7 @@ describe("typed arrays", () => {
 		})
 
 		expect(nextState).toEqual(new Uint16Array([50, 20, 0, 0]))
-		expect(patches).toEqual([
-			{
-				op: "replace",
-				path: [0],
-				value: 50
-			},
-			{
-				op: "replace",
-				path: [1],
-				value: 20
-			}
-		])
+		expect(patches).toEqual([])
 	})
 
 	it("should work when using a slice of an ArrayBuffer", () => {

--- a/src/core/current.ts
+++ b/src/core/current.ts
@@ -11,7 +11,8 @@ import {
 	ArchtypeMap,
 	ArchtypeSet,
 	getArchtype,
-	getPlugin
+	getPlugin,
+	ProxyTypeES5Object
 } from "../internal"
 
 /** Takes a snapshot of the current state of a draft and finalizes it (but without freezing). This is a great utility to print the current state during debugging (no Proxies in the way). The output of current can also be safely leaked outside the producer. */
@@ -29,7 +30,8 @@ function currentImpl(value: any): any {
 	if (state) {
 		if (
 			!state.modified_ &&
-			(state.type_ < 4 || !getPlugin("ES5").hasChanges_(state as any))
+			(state.type_ < ProxyTypeES5Object ||
+				!getPlugin("ES5").hasChanges_(state as any))
 		)
 			return state.base_
 		// Optimization: avoid generating new drafts during copying

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -13,6 +13,7 @@ import {
 	isDraft,
 	isMap,
 	isSet,
+	isTypedArray,
 	createProxyProxy,
 	getPlugin,
 	die,
@@ -217,6 +218,8 @@ export function createProxy<T extends Objectish>(
 		? getPlugin("MapSet").proxyMap_(value, parent)
 		: isSet(value)
 		? getPlugin("MapSet").proxySet_(value, parent)
+		: isTypedArray(value)
+		? getPlugin("TypedArrays").proxyTypedArray_(value, parent)
 		: immer.useProxies_
 		? createProxyProxy(value, parent)
 		: getPlugin("ES5").createES5Proxy_(value, parent)

--- a/src/core/scope.ts
+++ b/src/core/scope.ts
@@ -7,6 +7,7 @@ import {
 	ImmerState,
 	ProxyTypeProxyObject,
 	ProxyTypeProxyArray,
+	ProxyTypeTypedArray,
 	getPlugin
 } from "../internal"
 import {die} from "../utils/errors"
@@ -79,7 +80,8 @@ function revokeDraft(draft: Drafted) {
 	const state: ImmerState = draft[DRAFT_STATE]
 	if (
 		state.type_ === ProxyTypeProxyObject ||
-		state.type_ === ProxyTypeProxyArray
+		state.type_ === ProxyTypeProxyArray ||
+		state.type_ === ProxyTypeTypedArray
 	)
 		state.revoke_()
 	else state.revoked_ = true

--- a/src/immer.ts
+++ b/src/immer.ts
@@ -114,4 +114,5 @@ export {Immer}
 export {enableES5} from "./plugins/es5"
 export {enablePatches} from "./plugins/patches"
 export {enableMapSet} from "./plugins/mapset"
+export {enableTypedArrays} from "./plugins/typed-arrays"
 export {enableAllPlugins} from "./plugins/all"

--- a/src/plugins/all.ts
+++ b/src/plugins/all.ts
@@ -1,9 +1,11 @@
 import {enableES5} from "./es5"
 import {enableMapSet} from "./mapset"
 import {enablePatches} from "./patches"
+import {enableTypedArrays} from "./typed-arrays"
 
 export function enableAllPlugins() {
 	enableES5()
 	enableMapSet()
 	enablePatches()
+	enableTypedArrays()
 }

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -24,6 +24,7 @@ import {
 	ArchtypeMap,
 	ArchtypeSet,
 	ArchtypeArray,
+	ArchtypeTypedArray,
 	die,
 	isDraft,
 	isDraftable
@@ -226,6 +227,8 @@ export function enablePatches() {
 						/* istanbul ignore next */
 						case ArchtypeSet:
 							die(16)
+						case ArchtypeTypedArray:
+							die(24)
 						default:
 							// if value is an object, then it's assigned by reference
 							// in the following add or remove ops, the value field inside the patch will also be modifyed
@@ -241,6 +244,8 @@ export function enablePatches() {
 							return base.set(key, value)
 						case ArchtypeSet:
 							return base.add(value)
+						case ArchtypeTypedArray:
+							die(24)
 						default:
 							return (base[key] = value)
 					}
@@ -252,6 +257,8 @@ export function enablePatches() {
 							return base.delete(key)
 						case ArchtypeSet:
 							return base.delete(patch.value)
+						case ArchtypeTypedArray:
+							die(24)
 						default:
 							return delete base[key]
 					}

--- a/src/plugins/typed-arrays.ts
+++ b/src/plugins/typed-arrays.ts
@@ -1,0 +1,156 @@
+import {
+	DRAFT_STATE,
+	loadPlugin,
+	TypedArrayState,
+	ImmerState,
+	getCurrentScope,
+	die,
+	latest,
+	ProxyTypeTypedArray,
+	markChanged,
+	AnyTypedArray
+} from "../internal"
+
+export function enableTypedArrays() {
+	/**
+	 * Used for reusing the same underlying ArrayBuffer copy when there are multiple views on the same
+	 * ArrayBuffer
+	 */
+	const arrayBufferCopiesMap = new WeakMap<ArrayBuffer, ArrayBuffer>()
+
+	class TypedArrayProxy<T extends AnyTypedArray> {
+		[DRAFT_STATE]: TypedArrayState<T>
+
+		constructor(target: T, parent?: ImmerState) {
+			this[DRAFT_STATE] = {
+				type_: ProxyTypeTypedArray,
+				parent_: parent,
+				scope_: parent ? parent.scope_ : getCurrentScope(),
+				assigned_: {},
+				modified_: false,
+				finalized_: false,
+				isManual_: false,
+				base_: target,
+				copy_: undefined,
+				revoked_: false,
+				draft_: null as any, // set below
+				revoke_() {} // set below
+			}
+		}
+	}
+
+	const mutatingTypedArrayMethodNames: (keyof AnyTypedArray)[] = [
+		"copyWithin",
+		"fill",
+		"reverse",
+		"set",
+		"sort"
+	]
+	mutatingTypedArrayMethodNames.forEach(methodName => {
+		// @ts-ignore
+		TypedArrayProxy.prototype[methodName] = function(
+			this: TypedArrayProxy<any>,
+			...args: any[]
+		) {
+			assertUnrevoked(this[DRAFT_STATE])
+
+			prepareTypedArrayCopy(this[DRAFT_STATE])
+			const arr = latest(this[DRAFT_STATE])
+
+			return Object.getPrototypeOf(arr)[methodName].apply(arr, args)
+		}
+	})
+
+	const nonMutatingTypedArrayMethodNames = [
+		"entries",
+		"every",
+		"filter",
+		"find",
+		"findIndex",
+		"forEach",
+		"includes",
+		"indexOf",
+		"join",
+		"keys",
+		"lastIndexOf",
+		"map",
+		"reduce",
+		"reduceRight",
+		"slice",
+		"subarray",
+		"values",
+		"toLocaleString",
+		"toString",
+		Symbol.iterator
+	]
+	nonMutatingTypedArrayMethodNames.forEach(methodName => {
+		// @ts-ignore
+		TypedArrayProxy.prototype[methodName] = function(
+			this: TypedArrayProxy<any>,
+			...args: any[]
+		) {
+			const arr = latest(this[DRAFT_STATE])
+
+			return Object.getPrototypeOf(arr)[methodName].apply(arr, args)
+		}
+	})
+
+	function prepareTypedArrayCopy<T extends AnyTypedArray>(
+		state: TypedArrayState<T>
+	) {
+		if (state.copy_) return
+
+		if (arrayBufferCopiesMap.has(state.base_.buffer)) {
+			// Reuse the already copied underlying array buffer
+			const existingArrayBuffer = arrayBufferCopiesMap.get(state.base_.buffer)!
+			state.copy_ = new (Object.getPrototypeOf(state.base_).constructor)(
+				existingArrayBuffer
+			)
+		} else {
+			state.copy_ = state.base_.slice() as T
+			arrayBufferCopiesMap.set(state.base_.buffer, state.copy_.buffer)
+		}
+		markChanged(state)
+	}
+
+	function assertUnrevoked(state: TypedArrayState<any>) {
+		if (state.revoked_) die(3, JSON.stringify(latest(state)))
+	}
+
+	const typedArrayProxyTraps: ProxyHandler<TypedArrayProxy<any>> = {
+		get(target, prop) {
+			if (prop in target) {
+				// @ts-ignore
+				return target[prop]
+			}
+
+			return latest(target[DRAFT_STATE])[prop]
+		},
+		set(target, prop, value) {
+			prepareTypedArrayCopy(target[DRAFT_STATE])
+			target[DRAFT_STATE].assigned_[prop as number] = true
+
+			return Reflect.set(latest(target[DRAFT_STATE]), prop, value)
+		}
+	}
+
+	loadPlugin("TypedArrays", {
+		proxyTypedArray_(target, parent) {
+			const proxyWithoutArrayTraps = new TypedArrayProxy(target, parent)
+			const {revoke, proxy} = Proxy.revocable(
+				proxyWithoutArrayTraps,
+				typedArrayProxyTraps
+			)
+			proxyWithoutArrayTraps[DRAFT_STATE].revoke_ = () => {
+				revoke()
+				proxyWithoutArrayTraps[DRAFT_STATE].revoked_ = true
+				arrayBufferCopiesMap.delete(
+					proxyWithoutArrayTraps[DRAFT_STATE].base_.buffer
+				)
+			}
+			proxyWithoutArrayTraps[DRAFT_STATE].draft_ = proxy as any
+
+			return proxy as any
+		}
+	})
+}

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -1,4 +1,4 @@
-import {Nothing} from "../internal"
+import {Nothing, AnyTypedArray} from "../internal"
 
 type Tail<T extends any[]> = ((...t: T) => any) extends (
 	_: any,
@@ -50,6 +50,8 @@ export type Draft<T> = T extends AtomicObject
 	? Set<Draft<V>>
 	: T extends WeakReferences
 	? T
+	: T extends AnyTypedArray
+	? T
 	: T extends object
 	? WritableDraft<T>
 	: T
@@ -62,6 +64,8 @@ export type Immutable<T> = T extends AtomicObject
 	: T extends IfAvailable<ReadonlySet<infer V>> // Set extends ReadonlySet
 	? ReadonlySet<Immutable<V>>
 	: T extends WeakReferences
+	? T
+	: T extends AnyTypedArray
 	? T
 	: T extends object
 	? {readonly [K in keyof T]: Immutable<T[K]>}

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -18,9 +18,9 @@ type AtomicObject =
 	| String
 
 /**
- * If the lib "ES2105.collections" is not included in tsconfig.json,
+ * If the lib "ES2015.collections" is not included in tsconfig.json,
  * types like ReadonlyArray, WeakMap etc. fall back to `any` (specified nowhere)
- * or `{}` (from the node types), in both cases entering an infite recursion in
+ * or `{}` (from the node types), in both cases entering an infinite recursion in
  * pattern matching type mappings
  * This type can be used to cast these types to `void` in these cases.
  */

--- a/src/types/types-internal.ts
+++ b/src/types/types-internal.ts
@@ -5,6 +5,7 @@ import {
 	ProxyArrayState,
 	ES5ObjectState,
 	ES5ArrayState,
+	TypedArrayState,
 	MapState,
 	DRAFT_STATE
 } from "../internal"
@@ -16,18 +17,32 @@ export type AnyObject = {[key: string]: any}
 export type AnyArray = Array<any>
 export type AnySet = Set<any>
 export type AnyMap = Map<any, any>
+export type AnyTypedArray =
+	| Uint8Array
+	| Uint8ClampedArray
+	| Uint16Array
+	| Uint32Array
+	| Int8Array
+	| Int16Array
+	| Int32Array
+	| Float32Array
+	| Float64Array
+	| BigUint64Array
+	| BigInt64Array
 
 export const ArchtypeObject = 0
 export const ArchtypeArray = 1
 export const ArchtypeMap = 2
 export const ArchtypeSet = 3
+export const ArchtypeTypedArray = 4
 
 export const ProxyTypeProxyObject = 0
 export const ProxyTypeProxyArray = 1
-export const ProxyTypeES5Object = 4
-export const ProxyTypeES5Array = 5
+export const ProxyTypeES5Object = 5
+export const ProxyTypeES5Array = 6
 export const ProxyTypeMap = 2
 export const ProxyTypeSet = 3
+export const ProxyTypeTypedArray = 4
 
 export interface ImmerBaseState {
 	parent_?: ImmerState
@@ -44,6 +59,7 @@ export type ImmerState =
 	| ES5ArrayState
 	| MapState
 	| SetState
+	| TypedArrayState<AnyTypedArray>
 
 // The _internal_ type used for drafts (not to be confused with Draft, which is public facing)
 export type Drafted<Base = any, T extends ImmerState = ImmerState> = {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -16,11 +16,15 @@ import {
 	die,
 	AnyTypedArray
 } from "../internal"
-import {ProxyTypeES5Object, ArchtypeTypedArray} from "../types/types-internal"
+import {
+	ProxyTypeES5Object,
+	ArchtypeTypedArray,
+	ProxyTypeTypedArray
+} from "../types/types-internal"
 
 /** Returns true if the given value is an Immer draft */
 /*#__PURE__*/
-export function isDraft(value: any): boolean {
+export function isDraft(value: any): value is Drafted<unknown> {
 	return !!value && !!value[DRAFT_STATE]
 }
 
@@ -156,9 +160,11 @@ export function isSet(target: any): target is AnySet {
 /*#__PURE__*/
 export function isTypedArray(value: unknown): value is AnyTypedArray {
 	return (
-		ArrayBuffer.isView(value) &&
-		value.constructor !== DataView &&
-		value.constructor !== Buffer
+		(ArrayBuffer.isView(value) &&
+			value.constructor !== DataView &&
+			value.constructor !== Buffer) ||
+		// Proxies for TypedArrays do not pass `ArrayBuffer.isView`
+		(isDraft(value) && value[DRAFT_STATE].type_ === ProxyTypeTypedArray)
 	)
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -38,7 +38,8 @@ const errors = {
 	},
 	23(thing: string) {
 		return `'original' expects a draft, got: ${thing}`
-	}
+	},
+	24: "TypedArrays cannot have patches."
 } as const
 
 export function die(error: keyof typeof errors, ...args: any[]): never {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -31,7 +31,7 @@ const errors = {
 	},
 	20: "Cannot use proxies if Proxy, Proxy.revocable or Reflect are not available",
 	21(thing: string) {
-		return `produce can only be called on things that are draftable: plain objects, arrays, Map, Set or classes that are marked with '[immerable]: true'. Got '${thing}'`
+		return `produce can only be called on things that are draftable: plain objects, arrays, Map, Set, TypedArray or classes that are marked with '[immerable]: true'. Got '${thing}'`
 	},
 	22(thing: string) {
 		return `'current' expects a draft, got: ${thing}`

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -11,7 +11,9 @@ import {
 	ProxyTypeES5Object,
 	ProxyTypeMap,
 	ProxyTypeSet,
-	die
+	die,
+	ProxyTypeTypedArray,
+	AnyTypedArray
 } from "../internal"
 
 /** Plugin utilities */
@@ -42,6 +44,9 @@ const plugins: {
 	MapSet?: {
 		proxyMap_<T extends AnyMap>(target: T, parent?: ImmerState): T
 		proxySet_<T extends AnySet>(target: T, parent?: ImmerState): T
+	}
+	TypedArrays?: {
+		proxyTypedArray_<T extends AnyTypedArray>(target: T, parent?: ImmerState): T
 	}
 } = {}
 
@@ -105,6 +110,18 @@ export interface SetState extends ImmerBaseState {
 	drafts_: Map<any, Drafted> // maps the original value to the draft value in the new set
 	revoked_: boolean
 	draft_: Drafted<AnySet, SetState>
+}
+
+/** Typed Arrays plugin */
+export interface TypedArrayState<T extends AnyTypedArray>
+	extends ImmerBaseState {
+	type_: typeof ProxyTypeTypedArray
+	assigned_: Record<number | string, boolean>
+	copy_: T | undefined
+	base_: T
+	revoked_: boolean
+	draft_: Drafted<T, TypedArrayState<T>>
+	revoke_(): void
 }
 
 /** Patches plugin */


### PR DESCRIPTION
This is an attempt to fix #696 

This MR adds support for copy-on-write for TypedArrays (e.g. `Uint16Array`).

It correctly handles TypedArrays with the same underlying `ArrayBuffer`, so when copying 2 arrays with the same underlying buffer, the drafts will also have the same underlying buffer.

I was not sure how to handle ProxyTypes and Archtypes, so feel free to suggest another way to handle those. Also, do not hesitate listing things I could have done better 🙂 

## Limitations

I did not spend enough time to fix those. The known limitations/missing features are:

1. No support for patches
2. [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray](`TypedArray.subarray`) will not return a draft

## Possible optimizations

1. Not copying the array when the value is set to the same number

## Testing

Aside from the added automated tests, I did not test this feature extensively.