### PR TITLE
chore: use Buffer.from instead of deprecated new Buffer()

### DIFF
--- a/__tests__/manual.js
+++ b/__tests__/manual.js
@@ -23,7 +23,7 @@ function runTests(name, useProxies) {
 
 		it("should check arguments", () => {
 			expect(() => createDraft(3)).toThrowErrorMatchingSnapshot()
-			const buf = new Buffer([])
+			const buf = Buffer.from([])
 			expect(() => createDraft(buf)).toThrowErrorMatchingSnapshot()
 			expect(() => finishDraft({})).toThrowErrorMatchingSnapshot()
 		})


### PR DESCRIPTION
I noticed the test suite has a deprecation message about using `new Buffer([])` over `Buffer.from([])`. The buffer constructor usage was happening inside the test suite, so I thought I'd update the usage. The Node documentation says that using `Buffer.from` is equivalent, so I thought I'd update it. https://nodejs.org/docs/latest-v10.x/api/buffer.html#buffer_new_buffer_array

Running the test suite with this change removes the deprecation warning.