### PR TITLE
test: do not assume system timezone is UTC

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -1131,7 +1131,7 @@ test("#676 patching Date objects", () => {
 	}
 
 	const [nextState, patches] = produceWithPatches({}, function(draft) {
-		draft.date = new Date(2020, 10, 10, 8, 8, 8, 3)
+		draft.date = new Date(Date.UTC(2020, 10, 10, 8, 8, 8, 3))
 		draft.test = new Test()
 	})
 
@@ -1145,5 +1145,5 @@ test("#676 patching Date objects", () => {
 	expect(rebuilt.date.toJSON()).toMatchInlineSnapshot(
 		`"2020-11-10T08:08:08.003Z"`
 	)
-	expect(rebuilt.date).toEqual(new Date(2020, 10, 10, 8, 8, 8, 3))
+	expect(rebuilt.date).toEqual(new Date(Date.UTC(2020, 10, 10, 8, 8, 8, 3)))
 })


### PR DESCRIPTION
Fixes #712 by initializing all `Date` instances with UTC values, not local-timezone values.