### PR TITLE
Gender neutral language in the docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ The basic idea is that you will apply all your changes to a temporary _draftStat
 
 ![immer-hd.png](/immer/img/immer.png)
 
-Using Immer is like having a personal assistant; he takes a letter (the current state) and gives you a copy (draft) to jot changes onto. Once you are done, the assistant will take your draft and produce the real immutable, final letter for you (the next state).
+Using Immer is like having a personal assistant. The assistant takes a letter (the current state) and gives you a copy (draft) to jot changes onto. Once you are done, the assistant will take your draft and produce the real immutable, final letter for you (the next state).
 
 ## Quick Example
 


### PR DESCRIPTION
In the docs, I noticed there is an assumption in the example about the assistant's gender. This diff changes the text.

I had a version using "they" but when reading that back I was worried that non-native English speakers may get confused in this particular example since it is very early on in the docs and the example itself only serves as an elaboration of how draft state works. The version in this PR has the most clarity in my opinion, but I know that can be subjective. Happy to change it!