### PR TITLE
Perf: Use true primitive types in AtomicObject

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -13,9 +13,9 @@ type AtomicObject =
 	| Promise<any>
 	| Date
 	| RegExp
-	| Boolean
-	| Number
-	| String
+	| boolean
+	| number
+	| string
 
 /**
  * If the lib "ES2105.collections" is not included in tsconfig.json,


### PR DESCRIPTION
TypeScript will compare types to Boolean/Number/String structurally, but has special cases for boolean/number/string.  In local testing of a crazy edge case, this cut check time in half.