### PR TITLE
docs: add `break` to `switch` block

### DIFF
--- a/website/docs/example-reducer.mdx
+++ b/website/docs/example-reducer.mdx
@@ -67,6 +67,7 @@ const byId = produce((draft, action) => {
 			action.products.forEach(product => {
 				draft[product.id] = product
 			})
+			break
 	}
 }, INITIAL_STATE)
 ```


### PR DESCRIPTION
First off I love this package and appreciate everyone's work on it 🎉 

I get that there's only one `case` here and you want to have as few lines as possible but for people plucking this example and then using it to build out their own reducer, they'll immediately [run into issues][1] as soon as they add a second `case` with no `break` in the first. Given that many of your readers may be beginners, it seems safer to include.

[1]: https://stackoverflow.com/questions/8563970/switch-without-break