### PR TITLE
perf: isPlainObject: add quick comparison between input and `Object` to short-circuit taxing `Function.toString` invocations

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -46,6 +46,10 @@ export function isPlainObject(value: any): boolean {
 	}
 	const Ctor =
 		Object.hasOwnProperty.call(proto, "constructor") && proto.constructor
+
+	if (Ctor === Object)
+		return true
+
 	return (
 		typeof Ctor == "function" &&
 		Function.toString.call(Ctor) === objectCtorString


### PR DESCRIPTION
Fixes https://github.com/immerjs/immer/issues/804