### PR TITLE
Better applyPatches type

### DIFF
--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -185,7 +185,7 @@ export class Immer implements ProducersFns {
 		this.useProxies_ = value
 	}
 
-	applyPatches<T extends Objectish>(base: Objectish, patches: Patch[]): T {
+	applyPatches<T extends Objectish>(base: T, patches: Patch[]): T {
 		// If a patch replaces the entire state, take that replacement as base
 		// before applying patches
 		let i: number


### PR DESCRIPTION
applyPatches should specify its input as type `T` so that TypeScript can better infer the correct `T` for its output.

Fixes #809