### PR TITLE
doc: update example-setstate.mdx

### DIFF
--- a/website/docs/example-setstate.mdx
+++ b/website/docs/example-setstate.mdx
@@ -140,7 +140,7 @@ const TodoList = () => {
 					break
 				case "add":
 					draft.push({
-						id: "todo_" + Math.random(),
+						id: action.id,
 						title: "A new todo",
 						done: false
 					})
@@ -163,7 +163,8 @@ const TodoList = () => {
 
 	const handleAdd = useCallback(() => {
 		dispatch({
-			type: "add"
+			type: "add",
+			id: "todo_" + Math.random()
 		})
 	}, [])
 
@@ -189,7 +190,7 @@ const TodoList = () => {
           break;
         case "add":
           draft.push({
-            id: "todo_" + Math.random(),
+            id: action.id,
             title: "A new todo",
             done: false
           });
@@ -227,7 +228,7 @@ const todosReducer = produce((draft, action) => {
 			break
 		case "add":
 			draft.push({
-				id: "todo_" + Math.random(),
+				id: action.id,
 				title: "A new todo",
 				done: false
 			})


### PR DESCRIPTION
Moved id generation for new todos out of reducers to keep them pure.

The main behind this PR is, that reducers should be pure functions. And it would be great if docs of other libs also don't violate this rule in their examples.
![image](https://user-images.githubusercontent.com/35494518/127680121-8b62c7b4-9d34-41bd-95f9-1a71fea7514e.png)
