### PR TITLE
async produceWithPatches

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -1728,6 +1728,18 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 					})
 				})
 			})
+
+			it("works with patches", () =>
+				produceWithPatches({a: 0}, async d => {
+					await Promise.resolve()
+					d.a = 1
+				}).then(([nextState, patches, inversePathes]) => {
+					expect(nextState).toEqual({a: 1})
+					expect(patches).toEqual([{op: "replace", path: ["a"], value: 1}])
+					expect(inversePathes).toEqual([
+						{op: "replace", path: ["a"], value: 0}
+					])
+				}))
 		})
 
 		it("throws when the draft is modified and another object is returned", () => {

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -132,11 +132,15 @@ export class Immer implements ProducersFns {
 		}
 
 		let patches: Patch[], inversePatches: Patch[]
-		const nextState = this.produce(arg1, arg2, (p: Patch[], ip: Patch[]) => {
+		const result = this.produce(arg1, arg2, (p: Patch[], ip: Patch[]) => {
 			patches = p
 			inversePatches = ip
 		})
-		return [nextState, patches!, inversePatches!]
+
+		if (typeof Promise !== "undefined" && result instanceof Promise) {
+			return result.then(nextState => [nextState, patches!, inversePatches!])
+		}
+		return [result, patches!, inversePatches!]
 	}
 
 	createDraft<T extends Objectish>(base: T): Draft<T> {


### PR DESCRIPTION
Fixes `produce` and `produceWithPatches` behaving differently when passed an async recipe. `produceWithPatches` returns:

```javascript
[ Promise { <pending> }, undefined, undefined ]
```
instead of a promise of `[nextState, patches, inversePatches]`