### PR TITLE
docs: fix mobile navbar menu styles

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,6 +17,7 @@ module.exports = {
 		},
 		navbar: {
 			title: "Immer",
+			style: "dark",
 			logo: {
 				src: "/img/immer-logo.svg",
 				alt: "Immer Logo"

--- a/website/src/css/immer-infima.css
+++ b/website/src/css/immer-infima.css
@@ -12,9 +12,14 @@ a:hover {
 	text-decoration: underline;
 }
 
+.navbar--dark {
+	--ifm-navbar-background-color: black;
+	--ifm-menu-color: white;
+	--ifm-menu-color-background-hover: rgba(255, 255, 255, 0.1);
+}
+
 .navbar--fixed-top {
 	color: white;
-	background: black;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
This PR fixes the mobile navbar menu styles. The mobile navbar menu was essentially unusable with the light theme and inconsistent with the navbar for the dark theme.

## Before
![Screenshot 2021-11-14 at 18-02-38 Introduction to Immer Immer](https://user-images.githubusercontent.com/2206639/141690943-15f6db1c-74c2-419b-84fd-1729b8c5d71e.png)
![Screenshot 2021-11-14 at 18-03-01 Introduction to Immer Immer](https://user-images.githubusercontent.com/2206639/141690951-ce91a612-582a-4c77-87dd-5fa59a4c8b50.png)

## After
![Screenshot 2021-11-14 at 18-02-53 Introduction to Immer Immer](https://user-images.githubusercontent.com/2206639/141690959-32837efa-2a07-4f37-a033-5841877568b3.png)
![Screenshot 2021-11-14 at 18-03-23 Introduction to Immer Immer](https://user-images.githubusercontent.com/2206639/141690966-ea8ea89d-24a4-49d7-bcea-a686a8d92ec6.png)