### PR TITLE
chore: typo dormal -> normal

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -218,7 +218,7 @@ export interface IProduce {
 		listener?: PatchListener
 	): Base
 
-	/** Promisified dormal producer */
+	/** Promisified normal producer */
 	<Base, D = Draft<Base>>(
 		base: Base,
 		recipe: (draft: D) => Promise<ValidRecipeReturnType<D>>,


### PR DESCRIPTION
Minor typo fix for a produce function overload