### PR TITLE
[minor] fix:change tree structure level in nested patches

### DIFF
--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -88,6 +88,8 @@ export class Immer implements ProducersFns {
 		// Only plain objects, arrays, and "immerable classes" are drafted.
 		if (isDraftable(base)) {
 			const scope = enterScope(this)
+			//when base is a draft,can't freeze
+			scope.canAutoFreeze_ = !isDraft(base)
 			const proxy = createProxy(this, base, undefined)
 			let hasError = true
 			try {


### PR DESCRIPTION

do not freeze drafts used by nesting

[issue](https://github.com/immerjs/immer/issues/916)