### PR TITLE
fix: Fix importing ES module from Node.js (#901)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "9.0.0-beta.1",
   "description": "Create your next immutable state by mutating the current one",
   "main": "dist/index.js",
-  "module": "dist/immer.esm.js",
+  "module": "dist/immer.esm.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/immer.esm.mjs",
+      "require": "./dist/index.js"
+    },
+    "./*": "./*"
+  },
   "umd:main": "dist/immer.umd.production.min.js",
   "unpkg": "dist/immer.umd.production.min.js",
   "jsdelivr": "dist/immer.umd.production.min.js",
-  "jsnext:main": "dist/immer.esm.js",
-  "react-native": "dist/immer.esm.js",
+  "jsnext:main": "dist/immer.esm.mjs",
+  "react-native": "dist/immer.esm.mjs",
   "source": "src/immer.ts",
   "types": "./dist/immer.d.ts",
   "typesVersions": {
@@ -32,7 +39,7 @@
     "watch": "jest --watch",
     "coverage": "jest --coverage",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage",
-    "build": "rimraf dist/ && tsdx build --name immer --format esm,cjs,umd && yarn build:flow",
+    "build": "rimraf dist/ && tsdx build --name immer --format esm,cjs,umd && cp dist/immer.esm.js dist/immer.esm.mjs && yarn build:flow",
     "build:flow": "cpx 'src/types/index.js.flow' dist -v",
     "publish-docs": "cd website && GIT_USER=mweststrate USE_SSH=true yarn docusaurus deploy",
     "start": "cd website && yarn start",


### PR DESCRIPTION
This pull request fixes #901 by publishing the ES module with the `.mjs` file extension.

For now, the existing ESM bundle `dist/immer.esm.js` is simply copied to `dist/immer.esm.mjs` building. This makes sure that there are no breaking changes, just in case any library includes the old file manually. In the next major release of Immer, the old bundle can be removed. By then jaredpalmer/tsdx#1059 might be released, which I believe will adapt the bundle file extensions.

This pull request also adds an `exports` field to `package.json`, which will make sure that Node.js will import the ES module when run in ESM mode. The wildcard export `"./*": "./*"` will make sure that any sub paths can be continued to be imported (for example something like `import 'immer/src/immer.ts'`, which makes this a non-breaking change.