### PR TITLE
docs: Update produce/mdx

### DIFF
--- a/website/docs/produce.mdx
+++ b/website/docs/produce.mdx
@@ -32,7 +32,7 @@ title: Using produce
 
 The Immer package exposes a default function that does all the work.
 
-`produce(currentState, recipe: (draftState) => void): nextState`
+`produce(baseState, recipe: (draftState) => void): nextState`
 
 `produce` takes a base state, and a _recipe_ that can be used to perform all the desired mutations on the `draft` that is passed in. The interesting thing about Immer is that the `baseState` will be untouched, but the `nextState` will reflect all changes made to `draftState`.
 


### PR DESCRIPTION
`produce` function operates on `baseState` and produces `nextState`. Everywhere in this docs original state called `baseState`, but in the first snippet it's called `currentState`. I'm renaming it for consistency.