### PR TITLE
Fix link to `return` on `produce` doc page

### DIFF
--- a/website/docs/produce.mdx
+++ b/website/docs/produce.mdx
@@ -40,7 +40,7 @@ Inside the recipe, all standard JavaScript APIs can be used on the `draft` objec
 
 Any of those mutations don't have to happen at the root, but it is allowed to modify anything anywhere deep inside the draft: `draft.todos[0].tags["urgent"].author.age = 56`
 
-Note that the recipe function itself normally doesn't return anything. However, it is possible to return in case you want to replace the `draft` object in its entirety with another object, for more details see [returning new data](return).
+Note that the recipe function itself normally doesn't return anything. However, it is possible to return in case you want to replace the `draft` object in its entirety with another object, for more details see [returning new data](./return.mdx).
 
 ## Example
 


### PR DESCRIPTION
The current format was linking to https://immerjs.github.io/immer/produce/return , which does not exist.

*Disclaimer: I'm not actually sure how to build/host/test these docs myself, but I based this change off of the changes in https://github.com/immerjs/immer/commit/bc359167ec53759f981f503a16a19a5e9a810159*