### PR TITLE
fix: incorrect return type for async produceWithPatches

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -248,7 +248,7 @@ export interface IProduceWithPatches {
 		base: Base,
 		recipe: (draft: D) => Promise<ValidRecipeReturnType<Base>>,
 		listener?: PatchListener
-	): PatchesTuple<Promise<Base>>
+	): Promise<PatchesTuple<Base>>
 }
 
 // Fixes #507: bili doesn't export the types of this file if there is no actual source in it..


### PR DESCRIPTION
👋 Hello, it looks to be a long standing definition but this line seems to be incorrect. 

For reference: 

<img width="549" alt="Screenshot 2022-05-05 at 01 50 10" src="https://user-images.githubusercontent.com/2750352/166849354-ec02dc27-5287-485f-b94b-a172e624d45c.png">


