### PR TITLE
fix: consistent recipe return type in produceWithPatches

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -241,12 +241,12 @@ export interface IProduceWithPatches {
 	): InferCurriedFromInitialStateAndRecipe<State, Recipe, true>
 	<Base, D = Draft<Base>>(
 		base: Base,
-		recipe: (draft: D) => ValidRecipeReturnType<Base>,
+		recipe: (draft: D) => ValidRecipeReturnType<D>,
 		listener?: PatchListener
 	): PatchesTuple<Base>
 	<Base, D = Draft<Base>>(
 		base: Base,
-		recipe: (draft: D) => Promise<ValidRecipeReturnType<Base>>,
+		recipe: (draft: D) => Promise<ValidRecipeReturnType<D>>,
 		listener?: PatchListener
 	): PatchesTuple<Promise<Base>>
 }


### PR DESCRIPTION
I believe this should be consistent with `produce` on lines [217][217] & [224][224] - otherwise, as a consumer of both functions I would need to double-up on my own typing to handle each separately.

[217]: https://github.com/mylesj/immer/blob/7894ba364c75425eb11ef6dfb70bc1360147554e/src/types/types-external.ts#L217
[224]: https://github.com/mylesj/immer/blob/7894ba364c75425eb11ef6dfb70bc1360147554e/src/types/types-external.ts#L224