### PR TITLE
fix: Use .esm.js module for backwards compatibility with old build tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "9.0.0-beta.1",
   "description": "Create your next immutable state by mutating the current one",
   "main": "dist/index.js",
-  "module": "dist/immer.esm.mjs",
+  "module": "dist/immer.esm.js",
   "exports": {
     ".": {
       "import": "./dist/immer.esm.mjs",
@@ -14,8 +14,8 @@
   "umd:main": "dist/immer.umd.production.min.js",
   "unpkg": "dist/immer.umd.production.min.js",
   "jsdelivr": "dist/immer.umd.production.min.js",
-  "jsnext:main": "dist/immer.esm.mjs",
-  "react-native": "dist/immer.esm.mjs",
+  "jsnext:main": "dist/immer.esm.js",
+  "react-native": "dist/immer.esm.js",
   "source": "src/immer.ts",
   "types": "./dist/immer.d.ts",
   "typesVersions": {


### PR DESCRIPTION
Some people have reported trouble with the new release of immer, in particular in #937 and #921. The reason seems to be that older build tools are having trouble to understand `.mjs` files as JavaScript.

Since currently immer publishes both an `.esm.js` and `.esm.mjs` bundle (introduced in #921), with the whole purpose of being backwards compatible, in this pull request I'm reverting the `module` and other fields in `package.json` to using the `.esm.js` bundle, while only the `exports` field uses the `.esm.mjs` bundle. I'm hoping that this will achieve both compatibility with Node.js as well as ancient build tools.