### PR TITLE
[breaking change] implement and default to useStrictShallowCopy, omitting getters

### DIFF
--- a/__performance_tests__/large-obj.js
+++ b/__performance_tests__/large-obj.js
@@ -1,0 +1,62 @@
+import {measure} from "./measure"
+import produce, {
+	setUseProxies,
+	setUseStrictShallowCopy,
+	enableAllPlugins
+} from "../dist/immer.cjs.production.min.js"
+
+enableAllPlugins()
+
+console.log("\n# large-obj - mutate large object\n")
+
+const MAX = 50
+
+const baseState = Object.fromEntries(
+	Array(10000)
+		.fill(0)
+		.map((_, i) => [i, i])
+)
+
+measure("immer (proxy) - with setUseStrictShallowCopy", () => {
+	setUseStrictShallowCopy(true)
+	setUseProxies(true)
+
+	for (let i = 0; i < MAX; i++) {
+		produce(baseState, draft => {
+			draft[5000]++
+		})
+	}
+})
+
+measure("immer (proxy) - without setUseStrictShallowCopy", () => {
+	setUseStrictShallowCopy(false)
+	setUseProxies(true)
+
+	for (let i = 0; i < MAX; i++) {
+		produce(baseState, draft => {
+			draft[5000]++
+		})
+	}
+})
+
+measure("immer (es5) - with setUseStrictShallowCopy", () => {
+	setUseStrictShallowCopy(true)
+	setUseProxies(false)
+
+	for (let i = 0; i < MAX; i++) {
+		produce(baseState, draft => {
+			draft[5000]++
+		})
+	}
+})
+
+measure("immer (es5) - without setUseStrictShallowCopy", () => {
+	setUseStrictShallowCopy(false)
+	setUseProxies(false)
+
+	for (let i = 0; i < MAX; i++) {
+		produce(baseState, draft => {
+			draft[5000]++
+		})
+	}
+})

--- a/__tests__/__prod_snapshots__/base.js.snap
+++ b/__tests__/__prod_snapshots__/base.js.snap
@@ -56,6 +56,118 @@ exports[`base functionality - es5 (patch listener) set drafts revokes sets 2`] =
 
 exports[`base functionality - es5 (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
 exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
@@ -127,6 +239,150 @@ exports[`base functionality - proxy (patch listener) throws when Object.definePr
 exports[`base functionality - proxy (patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`base functionality - proxy (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] minified error nr: 3 '{}'. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] minified error nr: 11. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] minified error nr: 12. Find the full error at: https://bit.ly/3cXEKWf"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] minified error nr: 4. Find the full error at: https://bit.ly/3cXEKWf"`;
 
 exports[`complex nesting map / set / object modify deep object 1`] = `
 Object {
@@ -478,6 +734,382 @@ Object {
 `;
 
 exports[`complex nesting map / set / object modify deep object 16`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 17`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 18`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 19`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 20`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 21`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 22`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 23`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 24`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 25`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 26`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 27`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 28`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 29`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 30`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 31`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 32`] = `
 Array [
   Object {
     "op": "remove",

--- a/__tests__/__snapshots__/base.js.snap
+++ b/__tests__/__snapshots__/base.js.snap
@@ -1,260 +1,516 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`base functionality - es5 (autofreeze) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (autofreeze) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (autofreeze) revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (autofreeze) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (no freeze) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (no freeze) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (no freeze) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (no freeze) revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (no freeze) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (no freeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (patch listener) async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (patch listener) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - es5 (patch listener) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (patch listener) revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - es5 (patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - es5 (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=false:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze) array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (autofreeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (autofreeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true async recipe function works with rejected promises 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":0,\\"b\\":1}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (autofreeze)(patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (no freeze) array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (no freeze) array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (no freeze) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {\\"a\\":1}"`;
 
-exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 3`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (no freeze) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 4`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? [1]"`;
 
-exports[`base functionality - proxy (no freeze) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (no freeze) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - es5:auto-freeze=true:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (no freeze) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (no freeze) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (no freeze) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (patch listener) map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (patch listener) recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
 
-exports[`base functionality - proxy (patch listener) recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
-exports[`base functionality - proxy (patch listener) revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
 
-exports[`base functionality - proxy (patch listener) set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
 
-exports[`base functionality - proxy (patch listener) throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=false:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=false:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=false throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true array drafts throws when a non-numeric property is added 1`] = `"[Immer] Immer only supports setting array indices and the 'length' property"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true array drafts throws when a non-numeric property is deleted 1`] = `"[Immer] Immer only supports deleting array indices"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true async recipe function works with rejected promises 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true map drafts revokes map proxies 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return a modified child draft 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true recipe functions cannot return an object that references itself 1`] = `"[Immer] Immer forbids circular references"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 1`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 2`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 3`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 4`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 5`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 6`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 7`] = `"Cannot perform 'get' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true revokes the draft once produce returns 8`] = `"Cannot perform 'set' on a proxy that has been revoked"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 1`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true set drafts revokes sets 2`] = `"[Immer] Cannot use a proxy that has been revoked. Did you pass an object from inside an immer function to an async process? {}"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when Object.defineProperty() is used on drafts 1`] = `"[Immer] Object.defineProperty() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when Object.setPrototypeOf() is used on a draft 1`] = `"[Immer] Object.setPrototypeOf() cannot be used on an Immer draft"`;
+
+exports[`base functionality - proxy:auto-freeze=true:shallow-copy=true:use-listener=true throws when the draft is modified and another object is returned 1`] = `"[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft."`;
 
 exports[`complex nesting map / set / object modify deep object 1`] = `
 Object {
@@ -606,6 +862,382 @@ Object {
 `;
 
 exports[`complex nesting map / set / object modify deep object 16`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 17`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 18`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 19`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 20`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 21`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 22`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 23`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 24`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 25`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 26`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 27`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 28`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 29`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 30`] = `
+Array [
+  Object {
+    "op": "remove",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 1,
+    },
+  },
+  Object {
+    "op": "add",
+    "path": Array [
+      "map",
+      "set1",
+      0,
+    ],
+    "value": Object {
+      "a": 2,
+    },
+  },
+]
+`;
+
+exports[`complex nesting map / set / object modify deep object 31`] = `
+Object {
+  "map": Map {
+    "set1" => Set {
+      Object {
+        "a": 2,
+      },
+      Object {
+        "b": 2,
+      },
+    },
+    "set2" => Set {
+      Object {
+        "c": 3,
+      },
+    },
+  },
+}
+`;
+
+exports[`complex nesting map / set / object modify deep object 32`] = `
 Array [
   Object {
     "op": "remove",

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -952,6 +952,7 @@ function runBaseTest(
 					enumerable: false
 				})
 
+				// TODO: Should I change the implementation to make the behavior unambiguous?
 				const canReferNonEnumerableProperty = useProxies || useStrictShallowCopy
 				const nextState = produce(baseState, s => {
 					if (canReferNonEnumerableProperty) expect(s.foo).toBeTruthy()

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -952,7 +952,7 @@ function runBaseTest(
 					enumerable: false
 				})
 
-				// TODO: Should I change the implementation to make the behavior unambiguous?
+				// When using Proxy, even non-enumerable keys will be copied if it's changed.
 				const canReferNonEnumerableProperty = useProxies || useStrictShallowCopy
 				const nextState = produce(baseState, s => {
 					if (canReferNonEnumerableProperty) expect(s.foo).toBeTruthy()

--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -946,7 +946,7 @@ function runBaseTest(
 					value: 1,
 					enumerable: false
 				})
-				// Non-enumerable primitive property that don't refer
+				// Non-enumerable primitive property that won't modified.
 				Object.defineProperty(baseState, "baz", {
 					value: 1,
 					enumerable: false

--- a/__tests__/not-strict-copy.ts
+++ b/__tests__/not-strict-copy.ts
@@ -1,0 +1,39 @@
+import produce, {enableAllPlugins, setUseStrictShallowCopy} from "../src/immer"
+
+enableAllPlugins()
+
+describe("setUseStrictShallowCopy(true)", () => {
+	test("keep descriptors", () => {
+		setUseStrictShallowCopy(true)
+
+		const base: Record<string, unknown> = {}
+		Object.defineProperty(base, "foo", {
+			value: "foo",
+			writable: false,
+			configurable: false
+		})
+		const copy = produce(base, (draft: any) => {
+			draft.bar = "bar"
+		})
+		expect(Object.getOwnPropertyDescriptor(copy, "foo")).toStrictEqual(
+			Object.getOwnPropertyDescriptor(base, "foo")
+		)
+	})
+})
+
+describe("setUseStrictShallowCopy(false)", () => {
+	test("ignore descriptors", () => {
+		setUseStrictShallowCopy(false)
+
+		const base: Record<string, unknown> = {}
+		Object.defineProperty(base, "foo", {
+			value: "foo",
+			writable: false,
+			configurable: false
+		})
+		const copy = produce(base, (draft: any) => {
+			draft.bar = "bar"
+		})
+		expect(Object.getOwnPropertyDescriptor(copy, "foo")).toBeUndefined()
+	})
+})

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "jest && yarn test:build && yarn test:flow",
-    "test:perf": "cd __performance_tests__ && babel-node add-data.js && babel-node todo.js && babel-node incremental.js",
+    "test:perf": "cd __performance_tests__ && babel-node add-data.js && babel-node todo.js && babel-node incremental.js && babel-node large-obj.js",
     "test:flow": "yarn flow check __tests__/flow",
     "test:build": "yarn build && NODE_ENV='production' yarn jest --config jest.config.build.js",
     "watch": "jest --watch",

--- a/src/core/current.ts
+++ b/src/core/current.ts
@@ -33,10 +33,14 @@ function currentImpl(value: any): any {
 			return state.base_
 		// Optimization: avoid generating new drafts during copying
 		state.finalized_ = true
-		copy = copyHelper(value, archType)
+		copy = copyHelper(
+			value,
+			archType,
+			state.scope_.immer_.useStrictShallowCopy_
+		)
 		state.finalized_ = false
 	} else {
-		copy = copyHelper(value, archType)
+		copy = copyHelper(value, archType, true)
 	}
 
 	each(copy, (key, childValue) => {
@@ -47,7 +51,7 @@ function currentImpl(value: any): any {
 	return archType === Archtype.Set ? new Set(copy) : copy
 }
 
-function copyHelper(value: any, archType: number): any {
+function copyHelper(value: any, archType: number, strict: boolean): any {
 	// creates a shallow copy, even if it is a map or set
 	switch (archType) {
 		case Archtype.Map:
@@ -56,5 +60,5 @@ function copyHelper(value: any, archType: number): any {
 			// Set will be cloned as array temporarily, so that we can replace individual items
 			return Array.from(value)
 	}
-	return shallowCopy(value)
+	return shallowCopy(value, strict)
 }

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -83,7 +83,10 @@ function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
 		const result =
 			// For ES5, create a good copy from the draft first, with added keys and without deleted keys.
 			state.type_ === ProxyType.ES5Object || state.type_ === ProxyType.ES5Array
-				? (state.copy_ = shallowCopy(state.draft_))
+				? (state.copy_ = shallowCopy(
+						state.draft_,
+						rootScope.immer_.useStrictShallowCopy_
+				  ))
 				: state.copy_
 		// Finalize all children of the copy
 		// For sets we clone before iterating, otherwise we can get in endless loop due to modifying during iteration, see #628

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -37,11 +37,19 @@ export class Immer implements ProducersFns {
 
 	autoFreeze_: boolean = true
 
-	constructor(config?: {useProxies?: boolean; autoFreeze?: boolean}) {
+	useStrictShallowCopy_: boolean = true
+
+	constructor(config?: {
+		useProxies?: boolean
+		autoFreeze?: boolean
+		useStrictShallowCopy?: boolean
+	}) {
 		if (typeof config?.useProxies === "boolean")
 			this.setUseProxies(config!.useProxies)
 		if (typeof config?.autoFreeze === "boolean")
 			this.setAutoFreeze(config!.autoFreeze)
+		if (typeof config?.useStrictShallowCopy === "boolean")
+			this.setUseStrictShallowCopy(config!.useStrictShallowCopy)
 	}
 
 	/**
@@ -193,6 +201,15 @@ export class Immer implements ProducersFns {
 			die(20)
 		}
 		this.useProxies_ = value
+	}
+
+	/**
+	 * Pass false to disable strict shallow copy.
+	 *
+	 * By default, immer copies the object descriptors on creating new object.
+	 */
+	setUseStrictShallowCopy(value: boolean) {
+		this.useStrictShallowCopy_ = value
 	}
 
 	applyPatches<T extends Objectish>(base: T, patches: Patch[]): T {

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -37,7 +37,7 @@ export class Immer implements ProducersFns {
 
 	autoFreeze_: boolean = true
 
-	useStrictShallowCopy_: boolean = true
+	useStrictShallowCopy_: boolean = false
 
 	constructor(config?: {
 		useProxies?: boolean
@@ -204,9 +204,9 @@ export class Immer implements ProducersFns {
 	}
 
 	/**
-	 * Pass false to disable strict shallow copy.
+	 * Pass true to enable strict shallow copy.
 	 *
-	 * By default, immer copies the object descriptors on creating new object.
+	 * By default, immer does not copy the object descriptors such as getter, setter and non-enumrable properties.
 	 */
 	setUseStrictShallowCopy(value: boolean) {
 		this.useStrictShallowCopy_ = value

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -17,6 +17,7 @@ import {
 	createProxy,
 	ProxyType
 } from "../internal"
+import {ImmerScope} from "./scope"
 
 interface ProxyBaseState extends ImmerBaseState {
 	assigned_: {
@@ -273,8 +274,15 @@ export function markChanged(state: ImmerState) {
 	}
 }
 
-export function prepareCopy(state: {base_: any; copy_: any}) {
+export function prepareCopy(state: {
+	base_: any
+	copy_: any
+	scope_: ImmerScope
+}) {
 	if (!state.copy_) {
-		state.copy_ = shallowCopy(state.base_)
+		state.copy_ = shallowCopy(
+			state.base_,
+			state.scope_.immer_.useStrictShallowCopy_
+		)
 	}
 }

--- a/src/immer.ts
+++ b/src/immer.ts
@@ -68,6 +68,13 @@ export const setAutoFreeze = immer.setAutoFreeze.bind(immer)
 export const setUseProxies = immer.setUseProxies.bind(immer)
 
 /**
+ * Pass false to disable strict shallow copy.
+ *
+ * By default, immer copies the object descriptors on creating new object.
+ */
+export const setUseStrictShallowCopy = immer.setUseStrictShallowCopy.bind(immer)
+
+/**
  * Apply an array of Immer patches to the first argument.
  *
  * This function is a producer, which means copy-on-write is in effect.

--- a/src/immer.ts
+++ b/src/immer.ts
@@ -68,9 +68,9 @@ export const setAutoFreeze = immer.setAutoFreeze.bind(immer)
 export const setUseProxies = immer.setUseProxies.bind(immer)
 
 /**
- * Pass false to disable strict shallow copy.
+ * Pass true to enable strict shallow copy.
  *
- * By default, immer copies the object descriptors on creating new object.
+ * By default, immer does not copy the object descriptors such as getter, setter and non-enumrable properties.
  */
 export const setUseStrictShallowCopy = immer.setUseStrictShallowCopy.bind(immer)
 

--- a/src/types/index.js.flow
+++ b/src/types/index.js.flow
@@ -84,6 +84,13 @@ declare export function setAutoFreeze(autoFreeze: boolean): void
  */
 declare export function setUseProxies(useProxies: boolean): void
 
+/**
+ * Pass false to disable strict shallow copy.
+ *
+ * By default, immer copies the object descriptors on creating new object.
+ */
+declare export function setUseStrictShallowCopy(useStrictShallowCopy: boolean): void
+
 declare export function applyPatches<S>(state: S, patches: Patch[]): S
 
 declare export function original<S>(value: S): S

--- a/src/types/index.js.flow
+++ b/src/types/index.js.flow
@@ -87,7 +87,7 @@ declare export function setUseProxies(useProxies: boolean): void
 /**
  * Pass false to disable strict shallow copy.
  *
- * By default, immer copies the object descriptors on creating new object.
+ * By default, immer does not copy the object descriptors such as getter, setter and non-enumrable properties.
  */
 declare export function setUseStrictShallowCopy(useStrictShallowCopy: boolean): void
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -162,8 +162,19 @@ export function latest(state: ImmerState): any {
 }
 
 /*#__PURE__*/
-export function shallowCopy(base: any) {
+export function shallowCopy(base: any, strict: boolean) {
 	if (Array.isArray(base)) return Array.prototype.slice.call(base)
+
+	if (!strict && isPlainObject(base)) {
+		const keys = Object.keys(base)
+		const obj: any = Object.create(Object.getPrototypeOf(base))
+		for (let i = 0; i < keys.length; i++) {
+			const key = keys[i]
+			obj[key] = base[key]
+		}
+		return obj
+	}
+
 	const descriptors = getOwnPropertyDescriptors(base)
 	delete descriptors[DRAFT_STATE as any]
 	let keys = ownKeys(descriptors)

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -34,6 +34,7 @@ title: API overview
 | `produceWithPatches` | Works the same as `produce`, but instead of just returning the produced object, it returns a tuple, consisting of `[result, patches, inversePatches]`. | [Patches](./patches.mdx) |
 | `setAutoFreeze` | Enables / disables automatic freezing of the trees produces. By default enabled. | [Freezing](./freezing.mdx) |
 | `setUseProxies` | Can be used to disable or force the use of `Proxy` objects. Useful when filing bug reports. |  |
+| `setUseStrictShallowCopy` | Can be used to enable strict shallow copy. If enable, immer copies non-enumerable properties as much as possible. | [Classes](./complex-objects.md) |
 
 ## Importing immer
 

--- a/website/docs/complex-objects.md
+++ b/website/docs/complex-objects.md
@@ -58,13 +58,14 @@ console.log(clock2 instanceof Clock) // true
 
 The semantics on how classes are drafted are as follows:
 
+0. This description is valid only if strict shallow copy is enabled via `setUseStrictShallowCopy(true)`.
 1. A draft of a class is a fresh object but with the same prototype as the original object.
-2. When creating a draft, Immer will copy all _own_ properties from the base to the draft.This includes non-enumerable and symbolic properties.
-3. _Own_ getters will be invoked during the copy process, just like `Object.assign` would.
-4. Inherited getters and methods will remain as is and be inherited by the draft.
-5. Immer will not invoke constructor functions.
-6. The final instance will be constructed with the same mechanism as the draft was created.
-7. Only getters that have a setter as well will be writable in the draft, as otherwise the value can't be copied back.
+1. When creating a draft, Immer will copy all _own_ properties from the base to the draft.This includes non-enumerable and symbolic properties.
+1. _Own_ getters will be invoked during the copy process, just like `Object.assign` would.
+1. Inherited getters and methods will remain as is and be inherited by the draft.
+1. Immer will not invoke constructor functions.
+1. The final instance will be constructed with the same mechanism as the draft was created.
+1. Only getters that have a setter as well will be writable in the draft, as otherwise the value can't be copied back.
 
 Because Immer will dereference own getters of objects into normal properties, it is possible to use objects that use getter/setter traps on their fields, like MobX and Vue do.
 

--- a/website/docs/complex-objects.md
+++ b/website/docs/complex-objects.md
@@ -7,6 +7,8 @@ title: Classes
 <div data-ea-publisher="immerjs" data-ea-type="image" class="horizontal bordered"></div>
 </center>
 
+By default, Immer does not strictly handle Plain object's non-eumerable properties such as getters/setters for performance reason. If you want this behavior to be strict, you can opt-in with `useStrictShallowCopy(true)`.
+
 Plain objects (objects without a prototype), arrays, `Map`s and `Set`s are always drafted by Immer. Every other object must use the `immerable` symbol to mark itself as compatible with Immer. When one of these objects is mutated within a producer, its prototype is preserved between copies.
 
 ```js
@@ -58,9 +60,8 @@ console.log(clock2 instanceof Clock) // true
 
 The semantics on how classes are drafted are as follows:
 
-0. This description is valid only if strict shallow copy is enabled via `setUseStrictShallowCopy(true)`.
 1. A draft of a class is a fresh object but with the same prototype as the original object.
-1. When creating a draft, Immer will copy all _own_ properties from the base to the draft.This includes non-enumerable and symbolic properties.
+1. When creating a draft, Immer will copy all _own_ properties from the base to the draft.This includes non-enumerable and symbolic properties (if `useStrictShallowCopy(true)` was called).
 1. _Own_ getters will be invoked during the copy process, just like `Object.assign` would.
 1. Inherited getters and methods will remain as is and be inherited by the draft.
 1. Immer will not invoke constructor functions.


### PR DESCRIPTION
## Description

Fixes #867

This PR improves the performance when updating the object that contains a large number of entries.


### Problem

The current immer takes a long time for creating new object when the draft object has large amount of keys.

From some of the investigation, I found the cause that is `getOwnPropertyDescriptors` ([here](https://github.com/immerjs/immer/blob/master/src/utils/common.ts#L167)) .

In my computer, the `ownKeys` and its iteration don't take a long time but `getOwnPropertyDescriptors` takes time near the 10ms.

I can understand that the `getOwnPropertyDescriptors` is needed. Because immer should copy object's descriptors such as getter/setter/non-enumerable keys.

But some of the users doesn't need that strictness, I think.

### Solution

~~Add the ability to opt-out of strict shallow copy implementation for performance reasons.~~

`edited`

Make the default behavior not strict shallow copy. And add the ability to opt-in to strict shallow copying.

```ts
import { useStrictShallowCopy } from 'immer';

useStrictShallowCopy(true); // opt-in strict shallow copy.
```

### Result

The following results show the benefit of this patch.

```
// Iteration count:
//   50
//
// Base object: 
//   Array(10000)
//   	.fill(0)
//   	.map((_, i) => [i, i])
// 
// Test case:
//   for (let i = 0; i < MAX; i++) {
//   	produce(baseState, draft => {
//   		draft[5000]++
//   	})
//   }

# large-obj - mutate large object

immer (proxy) - with setUseStrictShallowCopy: 354ms
immer (proxy) - without setUseStrictShallowCopy: 79ms
immer (es5) - with setUseStrictShallowCopy: 1228ms
immer (es5) - without setUseStrictShallowCopy: 655ms
```
