### PR TITLE
Add "types" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./dist/immer.esm.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/immer.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
This is required for TypeScript 4.7, otherwise it can't find the declaration file.