### PR TITLE
fix/issue-949: fix reference to the declaration file for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./dist/immer.esm.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/immer.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
Fix issue #949 

The declaration file for the module `immer` can now be found. 

```
Could not find a declaration file for module 'immer'. '/Users/demian/github/immer-repo/node_modules/immer/dist/index.js' implicitly has an 'any' type.
```