### PR TITLE
[breaking change] Do not replace array.length as patch when removing items

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -555,7 +555,7 @@ describe("arrays - splice middle", () => {
 		},
 		[
 			{op: "replace", path: ["x", 1], value: 3},
-			{op: "replace", path: ["x", "length"], value: 2}
+			{op: "remove", path: ["x", 2]}
 		]
 	)
 })
@@ -574,7 +574,8 @@ describe("arrays - multiple splice", () => {
 			{op: "replace", path: [1], value: 3},
 			{op: "replace", path: [2], value: 3},
 			{op: "replace", path: [4], value: 0},
-			{op: "replace", path: ["length"], value: 5}
+			{op: "remove", path: [6]},
+			{op: "remove", path: [5]}
 		]
 	)
 })
@@ -589,7 +590,7 @@ describe("arrays - modify and shrink", () => {
 		},
 		[
 			{op: "replace", path: ["x", 0], value: 4},
-			{op: "replace", path: ["x", "length"], value: 2}
+			{op: "remove", path: ["x", 2]}
 		],
 		[
 			{op: "replace", path: ["x", 0], value: 1},
@@ -634,7 +635,10 @@ describe("arrays - truncate", () => {
 		d => {
 			d.x.length -= 2
 		},
-		[{op: "replace", path: ["x", "length"], value: 1}],
+		[
+			{op: "remove", path: ["x", 2]},
+			{op: "remove", path: ["x", 1]}
+		],
 		[
 			{op: "add", path: ["x", 1], value: 2},
 			{op: "add", path: ["x", 2], value: 3}
@@ -649,7 +653,10 @@ describe("arrays - pop twice", () => {
 			d.x.pop()
 			d.x.pop()
 		},
-		[{op: "replace", path: ["x", "length"], value: 1}]
+		[
+			{op: "remove", path: ["x", 2]},
+			{op: "remove", path: ["x", 1]}
+		]
 	)
 })
 
@@ -664,7 +671,10 @@ describe("arrays - push multiple", () => {
 			{op: "add", path: ["x", 3], value: 4},
 			{op: "add", path: ["x", 4], value: 5}
 		],
-		[{op: "replace", path: ["x", "length"], value: 3}]
+		[
+			{op: "remove", path: ["x", 4]},
+			{op: "remove", path: ["x", 3]}
+		]
 	)
 })
 
@@ -684,7 +694,8 @@ describe("arrays - splice (expand)", () => {
 		[
 			{op: "replace", path: ["x", 1], value: 2},
 			{op: "replace", path: ["x", 2], value: 3},
-			{op: "replace", path: ["x", "length"], value: 3}
+			{op: "remove", path: ["x", 4]},
+			{op: "remove", path: ["x", 3]}
 		]
 	)
 })
@@ -699,7 +710,8 @@ describe("arrays - splice (shrink)", () => {
 		[
 			{op: "replace", path: ["x", 1], value: 6},
 			{op: "replace", path: ["x", 2], value: 5},
-			{op: "replace", path: ["x", "length"], value: 3}
+			{op: "remove", path: ["x", 4]},
+			{op: "remove", path: ["x", 3]}
 		],
 		[
 			{op: "replace", path: ["x", 1], value: 2},
@@ -817,7 +829,7 @@ describe("arrays - splice should should result in remove op.", () => {
 		d => {
 			d.splice(1, 1)
 		},
-		[{op: "replace", path: ["length"], value: 1}],
+		[{op: "remove", path: [1]}],
 		[{op: "add", path: [1], value: 2}]
 	)
 })
@@ -829,7 +841,7 @@ describe("arrays - NESTED splice should should result in remove op.", () => {
 		d => {
 			d.a.b.c.splice(1, 1)
 		},
-		[{op: "replace", path: ["a", "b", "c", "length"], value: 1}],
+		[{op: "remove", path: ["a", "b", "c", 1]}],
 		[{op: "add", path: ["a", "b", "c", 1], value: 2}]
 	)
 })

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -104,11 +104,11 @@ export function enablePatches() {
 				value: clonePatchValueIfNeeded(copy_[i])
 			})
 		}
-		if (base_.length < copy_.length) {
+		for (let i = copy_.length - 1; base_.length <= i; --i) {
+			const path = basePath.concat([i])
 			inversePatches.push({
-				op: REPLACE,
-				path: basePath.concat(["length"]),
-				value: base_.length
+				op: REMOVE,
+				path
 			})
 		}
 	}


### PR DESCRIPTION
Patches generated by the current implementation do not follow the RFC method for removing an element from an array (https://www.rfc-editor.org/rfc/rfc6902#page-13) and cannot be used from other languages (e.g., https://pypi.org/project/jsonpatch/).