### PR TITLE
protect against undefined constructor

### DIFF
--- a/__tests__/isDraftable.js
+++ b/__tests__/isDraftable.js
@@ -1,0 +1,7 @@
+"use strict"
+import { isDraftable } from "../src/immer"
+
+test("non-plain object with undefined constructor doesn't error", () => {
+    const obj = Object.create(Object.create(null))
+    expect(isDraftable(obj).toBe(true);
+})

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -27,7 +27,7 @@ export function isDraftable(value: any): boolean {
 		isPlainObject(value) ||
 		Array.isArray(value) ||
 		!!value[DRAFTABLE] ||
-		!!value.constructor[DRAFTABLE] ||
+		!!value.constructor?.[DRAFTABLE] ||
 		isMap(value) ||
 		isSet(value)
 	)


### PR DESCRIPTION
Edge case where constructor is not defined on an object, such as `Object.create(null)`.