### PR TITLE
remove unused arg3 in produceWithPatches

### DIFF
--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -128,17 +128,17 @@ export class Immer implements ProducersFns {
 	}
 
 	produceWithPatches: IProduceWithPatches = (
-		arg1: any,
-		arg2?: any,
-		arg3?: any
+		base: any,
+		recipe?: any,
 	): any => {
-		if (typeof arg1 === "function") {
+		// curried invocation
+		if (typeof base === "function") {
 			return (state: any, ...args: any[]) =>
-				this.produceWithPatches(state, (draft: any) => arg1(draft, ...args))
+				this.produceWithPatches(state, (draft: any) => base(draft, ...args))
 		}
 
 		let patches: Patch[], inversePatches: Patch[]
-		const result = this.produce(arg1, arg2, (p: Patch[], ip: Patch[]) => {
+		const result = this.produce(base, recipe, (p: Patch[], ip: Patch[]) => {
 			patches = p
 			inversePatches = ip
 		})


### PR DESCRIPTION
Reading the source code, I came across an unused `arg3`. Seems like it initially threw an error if it was provided to guard against developers mistakenly passing in a patch listener, so basically unsupported from the beginning:

https://github.com/immerjs/immer/blame/ee1c977f5bf86e0f209e3df5f17bbc5bffb99dc3/src/immerClass.ts#L171
https://github.com/immerjs/immer/commit/86be737d8502aeb351296afe28ceb3e506a3a2ec#diff-3a3d78b97c1f27bfee63f1d6c1ca4e45d828fecfc6ed4ec7be92eea461639d6bR101