### PR TITLE
[minor] Preserve insertion order of Sets, fixes #819

### DIFF
--- a/__tests__/map-set.js
+++ b/__tests__/map-set.js
@@ -296,4 +296,38 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 			expect(mapType1).toBe(mapType2)
 		})
 	})
+	describe("set issues " + name, () => {
+		test("#819.A - maintains order when adding", () => {
+			const objs = [
+				"a",
+				{
+					id: "b"
+				}
+			]
+
+			const set = new Set([objs[0]])
+			const newSet = produce(set, draft => {
+				draft.add(objs[1])
+			})
+
+			// passes
+			expect(Array.from(newSet)).toEqual([objs[0], objs[1]])
+		})
+
+		test("#819.B - maintains order when adding", () => {
+			const objs = [
+				{
+					id: "a"
+				},
+				"b"
+			]
+
+			const set = new Set([objs[0]])
+			const newSet = produce(set, draft => {
+				draft.add(objs[1])
+			})
+
+			expect(Array.from(newSet)).toEqual([objs[0], objs[1]])
+		})
+	})
 }

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -87,12 +87,19 @@ function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
 				: state.copy_
 		// Finalize all children of the copy
 		// For sets we clone before iterating, otherwise we can get in endless loop due to modifying during iteration, see #628
+		// To preserve insertion order in all cases we then clear the set
+		// And we let finalizeProperty know it needs to re-add non-draft children back to the target
 		// Although the original test case doesn't seem valid anyway, so if this in the way we can turn the next line
 		// back to each(result, ....)
-		each(
-			state.type_ === ProxyType.Set ? new Set(result) : result,
-			(key, childValue) =>
-				finalizeProperty(rootScope, state, result, key, childValue, path)
+		let resultEach = result
+		let isSet = false
+		if (state.type_ === ProxyType.Set) {
+			resultEach = new Set(result)
+			result.clear()
+			isSet = true
+		}
+		each(resultEach, (key, childValue) =>
+			finalizeProperty(rootScope, state, result, key, childValue, path, isSet)
 		)
 		// everything inside is frozen, we can freeze here
 		maybeFreeze(rootScope, result, false)
@@ -115,7 +122,8 @@ function finalizeProperty(
 	targetObject: any,
 	prop: string | number,
 	childValue: any,
-	rootPath?: PatchPath
+	rootPath?: PatchPath,
+	targetIsSet?: boolean
 ) {
 	if (__DEV__ && childValue === targetObject) die(5)
 	if (isDraft(childValue)) {
@@ -134,6 +142,8 @@ function finalizeProperty(
 		if (isDraft(res)) {
 			rootScope.canAutoFreeze_ = false
 		} else return
+	} else if (targetIsSet) {
+		targetObject.add(childValue)
 	}
 	// Search new objects for unfinalized drafts. Frozen objects should never contain drafts.
 	if (isDraftable(childValue) && !isFrozen(childValue)) {

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -89,8 +89,6 @@ function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
 		// For sets we clone before iterating, otherwise we can get in endless loop due to modifying during iteration, see #628
 		// To preserve insertion order in all cases we then clear the set
 		// And we let finalizeProperty know it needs to re-add non-draft children back to the target
-		// Although the original test case doesn't seem valid anyway, so if this in the way we can turn the next line
-		// back to each(result, ....)
 		let resultEach = result
 		let isSet = false
 		if (state.type_ === ProxyType.Set) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -132,7 +132,6 @@ export function set(thing: any, propOrOldValue: PropertyKey, value: any) {
 	const t = getArchtype(thing)
 	if (t === Archtype.Map) thing.set(propOrOldValue, value)
 	else if (t === Archtype.Set) {
-		thing.delete(propOrOldValue)
 		thing.add(value)
 	} else thing[propOrOldValue] = value
 }


### PR DESCRIPTION
As pointed out in #819 insertion order is not always preserved when adding to a Set, though according to MDN it should be.

We were already cloning and iterating over the cloned Set anyway in `finalize`.

If we take it a step further to clear the original Set after cloning and let `finalizeProperty` know it needs to re-add non-draftable children back to the target then we end up rebuilding the Set in it's original order.

We then no longer need to delete anything from the Set in `set` 
