### PR TITLE
docs: Fix broken cdn link due to trailing fullwidth period

### DIFF
--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation.mdx
@@ -18,7 +18,7 @@ Immer 可以作为直接依赖项安装，并且可以在任何 ES5 环境中工
 - CDN: 暴露的全局变量是 `immer`
   - Unpkg: `<script src="https://unpkg.com/immer"></script>`
   - JSDelivr: `<script src="https://cdn.jsdelivr.net/npm/immer"></script>`
-  - ⚠️ 使用 CDN 时，最好检查浏览器中的 url 并查看它解析为哪个版本，这样当更新发布时，您的用户不会意外地获得更新的版本。因此，请改用如下网址：https://unpkg.com/immer@6.0.3/dist/immer.umd.production.min.js。在 URL 中将 production.min 替换为 development 以进行开发构建。
+  - ⚠️ 使用 CDN 时，最好检查浏览器中的 url 并查看它解析为哪个版本，这样当更新发布时，您的用户不会意外地获得更新的版本。因此，请改用如下网址：https://unpkg.com/immer@6.0.3/dist/immer.umd.production.min.js 。在 URL 中将 production.min 替换为 development 以进行开发构建。
 
 ## 选择您的 Immer 版本
 


### PR DESCRIPTION
I found the CDN script link was broken at installation docs in language zh_CN, which has redundant words because of trailing fullwidth period symbol, insert space can fix it.