### PR TITLE
fix: export type "WritableDraft"

### DIFF
--- a/src/immer.ts
+++ b/src/immer.ts
@@ -17,7 +17,8 @@ export {
 	isDraftable,
 	NOTHING as nothing,
 	DRAFTABLE as immerable,
-	freeze
+	freeze,
+	WritableDraft
 } from "./internal"
 
 const immer = new Immer()


### PR DESCRIPTION
Hi there!

I encountered problems using a `Bazel` monorepository and `pnpm`, in a TypeScript (4.8+) project using Redux Toolkit. 

> The inferred type of 'xxxxxSlice' cannot be named without a reference to '.pnpm/immer@9.0.15/node_modules/immer/dist/internal'. This is likely not portable. A type annotation is necessary.  

More details [here](https://github.com/reduxjs/redux-toolkit/pull/473#issuecomment-1266554741).

**I could solve the issue, exporting `WritableDraft` from `immer`** (then exporting it again from RTK (alongside the already exported `Draft`)).   

I cannot explain why yet (does not happen with `yarn`), but it looks like I'm not the only one who encountered this error. See also [here](https://github.com/microsoft/TypeScript/issues/42873#issuecomment-1150754847). In my case, turning off `declaration` is not an option, as I am working an a public library and definitely want to generate the typings.

Please let me know if I should change/improve anything!
