### PR TITLE
fixed jsdoc parameter name

### DIFF
--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -59,7 +59,7 @@ export class Immer implements ProducersFns {
 	 * Note: This function is __bound__ to its `Immer` instance.
 	 *
 	 * @param {any} base - the initial state
-	 * @param {Function} producer - function that receives a proxy of the base state as first argument and which can be freely modified
+	 * @param {Function} recipe - function that receives a proxy of the base state as first argument and which can be freely modified
 	 * @param {Function} patchListener - optional function that will be called with all the patches produced here
 	 * @returns {any} a new state, or the initial state if nothing was modified
 	 */
@@ -127,10 +127,7 @@ export class Immer implements ProducersFns {
 		} else die(21, base)
 	}
 
-	produceWithPatches: IProduceWithPatches = (
-		base: any,
-		recipe?: any,
-	): any => {
+	produceWithPatches: IProduceWithPatches = (base: any, recipe?: any): any => {
 		// curried invocation
 		if (typeof base === "function") {
 			return (state: any, ...args: any[]) =>


### PR DESCRIPTION
This PR updates the jsdoc parameter name "producer" to "recipe" to make the ide hints work again (currently broken)

<img width="738" alt="image" src="https://user-images.githubusercontent.com/20717348/203489039-bb09a999-640b-4305-b2cf-986dfaa3058b.png">
