### PR TITLE
chore: set vscode default formatter to prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "javascript.validate.enable": false,
   "typescript.tsdk": "node_modules/typescript/lib",
   "jest.enableInlineErrorMessages": true,


### PR DESCRIPTION
I formatted the code using the default TS formatter again in https://github.com/immerjs/immer/pull/1007

Adding this as a separate PR to help avoid this issue for everyone