### PR TITLE
fix: ensure type exports is first

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "module": "dist/immer.esm.js",
   "exports": {
     ".": {
+      "types": "./dist/immer.d.ts",
       "import": "./dist/immer.esm.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/immer.d.ts"
+      "require": "./dist/index.js"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
## Summary
According to the typescript documentation: `Entry-point` for TypeScript resolution must occur first.

>Reference:  
> https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
