### PR TITLE
fix: Creates separate patches for sparse arrays (#1019)

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -710,7 +710,7 @@ describe("arrays - splice (shrink)", () => {
 	)
 })
 
-describe("arrays - delete", () => {
+describe("arrays - delete property at index", () => {
 	runPatchTest(
 		{
 			x: [
@@ -1394,27 +1394,27 @@ test("#888 patch to a primitive produces the primitive", () => {
 	}
 })
 
-describe("#879 delete item from array", () => {
+describe("#879, #1019 delete item from array", () => {
 	runPatchTest(
 		[1, 2, 3],
 		draft => {
 			delete draft[1]
 		},
-		[{op: "replace", path: [1], value: undefined}],
+		[{op: "remove", path: [1]}],
 		[{op: "replace", path: [1], value: 2}],
-		[1, undefined, 3]
+		[1, , 3]
 	)
 })
 
-describe("#879 delete item from array - 2", () => {
+describe("#879, #1019 delete item from array - 2", () => {
 	runPatchTest(
 		[1, 2, 3],
 		draft => {
 			delete draft[2]
 		},
-		[{op: "replace", path: [2], value: undefined}],
+		[{op: "remove", path: [2]}],
 		[{op: "replace", path: [2], value: 3}],
-		[1, 2, undefined]
+		[1, 2, ,]
 	)
 })
 

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -223,8 +223,7 @@ each(objectTraps, (key, fn) => {
 })
 arrayTraps.deleteProperty = function(state, prop) {
 	if (__DEV__ && isNaN(parseInt(prop as any))) die(13)
-	// @ts-ignore
-	return arrayTraps.set!.call(this, state, prop, undefined)
+	return objectTraps.deleteProperty!.call(this, state[0], prop)
 }
 arrayTraps.set = function(state, prop, value) {
 	if (__DEV__ && prop !== "length" && isNaN(parseInt(prop as any))) die(14)

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -90,6 +90,21 @@ export function enablePatches() {
 					path,
 					value: clonePatchValueIfNeeded(base_[i])
 				})
+			} else if (
+				// detecting `delete` ¡¡¡Use strict `false` check, NOT falsey!!!
+				assigned_[i] === false &&
+				// getting a hole returns undefined, use `hasOwnProperty` to detect holes
+				!copy_.hasOwnProperty(i) &&
+				// transitive assertion that `base_.hasOwnProperty(i)`
+				copy_[i] !== base_[i]
+			) {
+				const path = basePath.concat([i])
+				patches.push({op: REMOVE, path})
+				inversePatches.push({
+					op: REPLACE,
+					path,
+					value: clonePatchValueIfNeeded(base_[i])
+				})
 			}
 		}
 
@@ -253,7 +268,7 @@ export function enablePatches() {
 				case REMOVE:
 					switch (type) {
 						case Archtype.Array:
-							return base.splice(key as any, 1)
+							return delete base[key]
 						case Archtype.Map:
 							return base.delete(key)
 						case Archtype.Set:


### PR DESCRIPTION
- the goal is to create a separate patch 'flow' for `delete` operations that cause arrays to become sparse
- es5 tests are currently failing