### PR TITLE
Fix typings for `union` types

### DIFF
--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -43,9 +43,7 @@ export type Draft<T> = T extends PrimitiveType
 	? Set<Draft<V>>
 	: T extends WeakReferences
 	? T
-	: T extends object
-	? WritableDraft<T>
-	: T
+	: WritableDraft<T>
 
 /** Convert a mutable type into a readonly type */
 export type Immutable<T> = T extends PrimitiveType
@@ -58,9 +56,7 @@ export type Immutable<T> = T extends PrimitiveType
 	? ReadonlySet<Immutable<V>>
 	: T extends WeakReferences
 	? T
-	: T extends object
-	? {readonly [K in keyof T]: Immutable<T[K]>}
-	: T
+	: {readonly [K in keyof T]: Immutable<T[K]>}
 
 export interface Patch {
 	op: "replace" | "remove" | "add"


### PR DESCRIPTION
In cases where we have a union with `readonly` bits inside a `Draft`, the type is following the fallback to T instead of deconstructing the union (luckily for us, the union deconstruction is typed in the same way as object deconstruction, so the code can be simplified to simply fallback to `WritableDraft<T>` which covers both objects and unions).

This PR fixes very common use cases like `T | undefined`:

```ts
// BEFORE
type X = Draft<{ prop?: readonly string[] }>
//   ^? type X = { prop?: readonly string[] } // INCORRECT!

// AFTER
type X = Draft<{ prop?: readonly string[] }>
//   ^? type X = { prop?: string[] } // CORRECT!
```