### PR TITLE
fix: patching maps failed when using number keys

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -214,6 +214,24 @@ describe("simple assignment - 7", () => {
 	)
 })
 
+describe("simple assignment - 8", () => {
+	runPatchTest(
+		new Map([[0, new Map([[1, 4]])]]),
+		d => {
+			d.get(0).set(1, 5)
+			d.get(0).set(2, 6)
+		},
+		[
+			{op: "replace", path: [0, 1], value: 5},
+			{op: "add", path: [0, 2], value: 6}
+		],
+		[
+			{op: "replace", path: [0, 1], value: 4},
+			{op: "remove", path: [0, 2]}
+		]
+	)
+})
+
 describe("delete 1", () => {
 	runPatchTest(
 		{x: {y: 4}},

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -207,7 +207,11 @@ export function enablePatches() {
 			let base: any = draft
 			for (let i = 0; i < path.length - 1; i++) {
 				const parentType = getArchtype(base)
-				const p = "" + path[i]
+				let p = path[i]
+				if (typeof p !== "string" && typeof p !== "number") {
+					p = "" + p
+				}
+
 				// See #738, avoid prototype pollution
 				if (
 					(parentType === Archtype.Object || parentType === Archtype.Array) &&


### PR DESCRIPTION
This broke because of the mitigation for [CVE-2020-28477](https://github.com/advisories/GHSA-9qmh-276g-x5pj)

The solution should restore the behavior for maps with number key, while not bringing back the vulnerability.

Repro: https://stackblitz.com/edit/node-isqvrw?file=package.json
Fixes #952 