### PR TITLE
chore(docs): use named imports for "produce" (instead of default import)

### DIFF
--- a/website/docs/async.mdx
+++ b/website/docs/async.mdx
@@ -35,7 +35,7 @@ sidebar_label: Async produce / createDraft
 It is allowed to return Promise objects from recipes. Or, in other words, to use `async / await`. This can be pretty useful for long running processes, that only produce the new object once the promise chain resolves. Note that `produce` itself (even in the curried form) will return a promise if the producer is async. Example:
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const user = {
 	name: "michel",

--- a/website/docs/curried-produce.mdx
+++ b/website/docs/curried-produce.mdx
@@ -34,7 +34,7 @@ title: Curried producers
 Passing a function as the first argument to `produce` creates a function that doesn't apply `produce` yet to a specific state, but rather creates a function that will apply `produce` to any state that is passed to it in the future. This generally is called _currying_. Take for example the following example:
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 function toggleTodo(state, id) {
 	return produce(state, draft => {
@@ -62,7 +62,7 @@ const nextState = toggleTodo(baseState, "Immer")
 The above pattern of `toggleTodo` is quite typical; pass an existing state to `produce`, modify the `draft`, and then return the result. Since `state` isn't used for anything else than passing it on to `produce`, the above example can be simplified by using the _curried_ form of `produce`, where you pass `produce` only the recipe function, and `produce` will return a new function that will apply recipe to the base state. This allows us to shorten the above `toggleTodo` definition.
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // curried producer:
 const toggleTodo = produce((draft, id) => {

--- a/website/docs/example-setstate.mdx
+++ b/website/docs/example-setstate.mdx
@@ -37,7 +37,7 @@ The `useState` hook assumes any state that is stored inside it is treated as imm
 
 ```javascript
 import React, { useCallback, useState } from "react";
-import produce from "immer";
+import {produce} from "immer";
 
 const TodoList = () => {
   const [todos, setTodos] = useState([
@@ -128,7 +128,7 @@ Similarly to `useState`, `useReducer` combines neatly with Immer as well, as dem
 
 ```javascript
 import React, {useCallback, useReducer} from "react"
-import produce from "immer"
+import {produce} from "immer"
 
 const TodoList = () => {
 	const [todos, dispatch] = useReducer(
@@ -213,7 +213,7 @@ Redux + Immer is extensively covered in the documentation of [Redux Toolkit](htt
 For example:
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // Reducer with initial state
 const INITIAL_STATE = [

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -44,7 +44,7 @@ import {enableMapSet} from "immer"
 enableMapSet()
 
 // ...later
-import produce from "immer"
+import {produce} from "immer"
 
 const usersById_v1 = new Map([
 	["michel", {name: "Michel Weststrate", country: "NL"}]

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -76,7 +76,7 @@ nextState.push({title: "Tweet about it"})
 With Immer, this process is more straightforward. We can leverage the `produce` function, which takes as first argument the state we want to start from, and as second argument we pass a function, called the _recipe_, that is passed a `draft` to which we can apply straightforward mutations. Those mutations are recorded and used to produce the next state once the recipe is done. `produce` will take care of all the necessary copying, and protect against future accidental modifications as well by freezing the data.
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const nextState = produce(baseState, draft => {
 	draft[1].done = true

--- a/website/docs/patches.mdx
+++ b/website/docs/patches.mdx
@@ -64,7 +64,7 @@ Patches are useful in few scenarios:
 To help with replaying patches, `applyPatches` comes in handy. Here is an example how patches could be used to record the incremental updates and (inverse) apply them:
 
 ```javascript
-import produce, {applyPatches} from "immer"
+import {applyPatches, produce} from "immer"
 
 // version 6
 import {enablePatches} from "immer"

--- a/website/docs/produce.mdx
+++ b/website/docs/produce.mdx
@@ -45,7 +45,7 @@ Note that the recipe function itself normally doesn't return anything. However, 
 ## Example
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const baseState = [
 	{

--- a/website/docs/return.mdx
+++ b/website/docs/return.mdx
@@ -96,7 +96,7 @@ The problem is that in JavaScript a function that doesn't return anything also r
 However, to make it clear to Immer that you intentionally want to produce the value `undefined`, you can return the built-in token `nothing`:
 
 ```javascript
-import produce, {nothing} from "immer"
+import {nothing, produce} from "immer"
 
 const state = {
 	hello: "world"

--- a/website/docs/typescript.mdx
+++ b/website/docs/typescript.mdx
@@ -36,7 +36,7 @@ The Immer package ships with type definitions inside the package, which should b
 The TypeScript typings automatically remove `readonly` modifiers from your draft types and return a value that matches your original type. See this practical example:
 
 ```ts
-import produce from "immer"
+import {produce} from "immer"
 
 interface State {
 	readonly x: number

--- a/website/docs/update-patterns.md
+++ b/website/docs/update-patterns.md
@@ -14,7 +14,7 @@ To help 'unlearning' those patterns here is an overview how you can leverage the
 ### Object mutations
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const todosObj = {
 	id1: {done: false, body: "Take out the trash"},
@@ -40,7 +40,7 @@ const updatedTodosObj = produce(todosObj, draft => {
 ### Array mutations
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const todosArray = [
 	{id: "id1", done: false, body: "Take out the trash"},
@@ -107,7 +107,7 @@ const updatedTodosArray = produce(todosArray, draft => {
 ### Nested data structures
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // example complex data structure
 const store = {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/async.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/async.mdx
@@ -34,7 +34,7 @@ sidebar_label: 异步 produce / createDraft
 允许从 recipe 返回 Promise 对象。或者，换句话说，使用 `async / await`。这对于长时间运行的进程非常有用，只有在 Promise 链解析后才生成新对象。请注意，如果 producer 是异步的，`produce` 本身（即使是柯里化形式）也会返回一个 promise。例子:
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const user = {
 	name: "michel",

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/curried-produce.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/curried-produce.mdx
@@ -33,7 +33,7 @@ title: 柯里化 producers
 将函数作为第一个参数传递给 `produce` 会创建一个函数，该函数尚未将 `produce` 应用于特定 state，而是创建一个函数，该函数将应用于将来传递给它的任何 state。这通常称为柯里化。举个例子：
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 function toggleTodo(state, id) {
 	return produce(state, draft => {
@@ -61,7 +61,7 @@ const nextState = toggleTodo(baseState, "Immer")
 上面的 `toggleTodo` 模式非常典型；传递一个现有的 state 来 `produce`，修改 `draft`，然后返回结果。由于 `state` 除了将其传递给 `produce` 之外没有其他任何用途，因此可以通过使用 `produce` 的柯里化形式来简化上面的示例，其中您只传递 `produce` recipe 函数，并且 `produce` 将返回一个应用 recipe 到基础状态的新函数。这允许我们缩短上述 `toggleTodo` 定义。
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // curried producer:
 const toggleTodo = produce((draft, id) => {

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/example-setstate.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/example-setstate.mdx
@@ -37,7 +37,7 @@ title: React & Immer
 
 ```javascript
 import React, { useCallback, useState } from "react";
-import produce from "immer";
+import {produce} from "immer";
 
 const TodoList = () => {
   const [todos, setTodos] = useState([
@@ -128,7 +128,7 @@ const TodoList = () => {
 
 ```javascript
 import React, {useCallback, useReducer} from "react"
-import produce from "immer"
+import {produce} from "immer"
 
 const TodoList = () => {
 	const [todos, dispatch] = useReducer(
@@ -214,7 +214,7 @@ Redux + Immer 在 [Redux Toolkit](https://redux-toolkit.js.org/usage/immer-reduc
 例子:
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // 初始 state
 const INITIAL_STATE = [

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation.mdx
@@ -44,7 +44,7 @@ import {enableMapSet} from "immer"
 enableMapSet()
 
 // ...然后
-import produce from "immer"
+import {produce} from "immer"
 
 const usersById_v1 = new Map([
 	["michel", {name: "Michel Weststrate", country: "NL"}]

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/introduction.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/introduction.md
@@ -71,7 +71,7 @@ nextState.push({title: "Tweet about it"})
 使用 Immer，这个过程更加简单。我们可以利用 `produce` 函数，它将我们要更改的 state 作为第一个参数，对于第二个参数，我们传递一个名为 recipe 的函数，该函数传递一个 `draft` 参数，我们可以对其应用直接的 `mutations`。一旦 `recipe` 执行完成，这些 `mutations` 被记录并用于产生下一个状态。 `produce` 将负责所有必要的复制，并通过冻结数据来防止未来的意外修改。
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const nextState = produce(baseState, draft => {
 	draft[1].done = true

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/patches.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/patches.mdx
@@ -64,7 +64,7 @@ Patches 在下面场景很有用:
 为了帮助回溯补丁，`applyPatches` 派上用场了。这是一个如何使用 Patches 来记录增量更新并（反向）应用它们的示例：
 
 ```javascript
-import produce, {applyPatches} from "immer"
+import {applyPatches, produce} from "immer"
 
 // 版本 6
 import {enablePatches} from "immer"

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/produce.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/produce.mdx
@@ -46,7 +46,7 @@ Immer 包暴露了一个完成所有工作的默认函数。
 ## 例子
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const baseState = [
 	{

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/return.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/return.mdx
@@ -96,7 +96,7 @@ produce({}, draft => {
 但是，为了让 Immer 清楚您有意生成 `undefined` 值，您可以返回内置标记 `nothing`：
 
 ```javascript
-import produce, {nothing} from "immer"
+import {nothing, produce} from "immer"
 
 const state = {
 	hello: "world"

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/typescript.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/typescript.mdx
@@ -36,7 +36,7 @@ Immer 包附带了类型定义，TypeScript 和 Flow 开箱即可获取这些定
 TypeScript 类型会自动从 draft 类型中删除 `readonly` 修饰符，并返回与原始类型匹配的值。看这个实际的例子:
 
 ```ts
-import produce from "immer"
+import {produce} from "immer"
 
 interface State {
 	readonly x: number

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/update-patterns.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/update-patterns.md
@@ -14,7 +14,7 @@ title: 更新模式
 ### 更新对象
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const todosObj = {
 	id1: {done: false, body: "Take out the trash"},
@@ -40,7 +40,7 @@ const updatedTodosObj = produce(todosObj, draft => {
 ### 更新数组
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 const todosArray = [
 	{id: "id1", done: false, body: "Take out the trash"},
@@ -104,7 +104,7 @@ const updatedTodosArray = produce(todosArray, draft => {
 ### 嵌套数据结构
 
 ```javascript
-import produce from "immer"
+import {produce} from "immer"
 
 // 复杂数据结构例子
 const store = {


### PR DESCRIPTION
I decided to update the docs after my comment here:
https://github.com/immerjs/immer/issues/1015#issuecomment-1487913925

All I did was change:
```
import produce from "immer"
```
to:
```
import {produce} from "immer"
```

The other formatting changes are due to the `pre-commit` hook:
<img width="730" alt="image" src="https://user-images.githubusercontent.com/434470/228426867-e0364804-26ec-475e-be2c-da5041529444.png">

I used `{produce}` instead of `{ produce }` to follow the other examples in this repo (even though I typically use the "extra spaces for padding").

Let me know if there's anything else I should do. Thanks for the great work on this project!