### PR TITLE
do not throw an error when deleting a non-existant prop from draft

### DIFF
--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -743,3 +743,13 @@ it("allows for mixed property value types", () => {
 		}
 	})
 })
+
+it("can delete properties that do not exist on the draft", () => {
+	const newState = produce((draft: Draft<State>) => {
+		// @ts-expect-error
+		delete draft.aPropertyThatDoesNotExist
+		draft.num++
+	})(state)
+	expect(newState).not.toBe(state)
+	expect(newState.num).toBe(1)
+})

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -176,9 +176,9 @@ export const objectTraps: ProxyHandler<ProxyState> = {
 			markChanged(state)
 		} else {
 			// if an originally not assigned property was deleted
-			delete state.assigned_[prop]
+			delete state.assigned_?.[prop]
 		}
-		delete state.copy_[prop]
+		delete state.copy_?.[prop]
 		return true
 	},
 	// Note: We never coerce `desc.value` into an Immer draft, because we can't make


### PR DESCRIPTION
This should fix the issue found here:
https://github.com/immerjs/immer/issues/1015#issuecomment-1498535646

https://codesandbox.io/s/flamboyant-glitter-n2nevz?file=/src/App.js

cc @einarq / @mweststrate

The only concern I have: I did not look into how this library is being transpiled, or if "optional chaining" is used elsewhere in the code.  This change did appear to "fix" the new unit test I added