### PR TITLE
RFC should baseState be frozen in case the draft did not change any property

### DIFF
--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -115,6 +115,24 @@ it("cannot infer state type when the function type and default state are missing
 	assert(foo, _ as Recipe)
 })
 
+it("frozen status of the baseState after produce should be independent of the passed value", () => {
+	expect(Object.isFrozen(state)).toBe(false)
+
+	const updatedState = setNum(1)
+	expect(Object.isFrozen(state)).toBe(false)
+	expect(updatedState.num).toBe(1)
+
+	const equalState = setNum(state.num)
+	expect(Object.isFrozen(state)).toBe(false)
+	expect(equalState.num).toBe(state.num)
+})
+
+function setNum(newNum: number) {
+	return produce(state, draft => {
+		draft.num = newNum
+	})
+}
+
 it("can update readonly state via curried api", () => {
 	const newState = produce((draft: Draft<State>) => {
 		draft.num++


### PR DESCRIPTION
Something I ran into today and it surprised me. Want to check if this works as expected.
I put my expectation into the test that is currently failing.

First block changes num `0` -> `1`, works as expected, `state` is not frozen
```TypeScript
const updatedState = setNum(1)
expect(Object.isFrozen(state)).toBe(false)
expect(updatedState.num).toBe(1)
```

Second block produces num `0` -> `0`, but `state` is now frozen and I did no expect it.
```TypeScript
const equalState = setNum(state.num)
expect(Object.isFrozen(state)).toBe(false)
expect(equalState.num).toBe(state.num)
```

If this is expected behavior, is there an alternative api/configuration option where I can avoid that `state` is frozen?