### PR TITLE
non-enumerable (immutable) methods on Map/Set

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -188,7 +188,12 @@ export function freeze<T>(obj: T, deep?: boolean): T
 export function freeze<T>(obj: any, deep: boolean = false): T {
 	if (isFrozen(obj) || isDraft(obj) || !isDraftable(obj)) return obj
 	if (getArchtype(obj) > 1 /* Map or Set */) {
-		obj.set = obj.add = obj.clear = obj.delete = dontMutateFrozenCollections as any
+		 Object.defineProperties(obj, {
+                        set: {value: dontMutateFrozenCollections as any},
+                        add: {value: dontMutateFrozenCollections as any},
+                        clear: {value: dontMutateFrozenCollections as any},
+                        delete: {value: dontMutateFrozenCollections as any}
+                })
 	}
 	Object.freeze(obj)
 	if (deep) each(obj, (_key, value) => freeze(value, true), true)


### PR DESCRIPTION
when an immer object includes a Map/Set, the mutating methods are replaced with ones that prevent mutation outside of the produce function.   to prevent cluttering the console when inspecting the Map/Set, these methods are set to non-enumerable. this behavior also matches that of the original methods that are replaced.