### PR TITLE
Add Optional Support For Multiple References to an Object

### DIFF
--- a/website/docs/pitfalls.md
+++ b/website/docs/pitfalls.md
@@ -17,6 +17,8 @@ Never reassign the `draft` argument (example: `draft = myCoolNewState`). Instead
 
 ### Immer only supports unidirectional trees
 
+<!-- TODO: Discuss what to do in the docs regarding the multiple references PR -->
+
 Immer assumes your state to be a unidirectional tree. That is, no object should appear twice in the tree, there should be no circular references. There should be exactly one path from the root to any node of the tree.
 
 ### Never explicitly return `undefined` from a producer


### PR DESCRIPTION
Some state trees may need to reference an object more than once (such as the tree for my [fomod](https://www.npmjs.com/package/fomod) library). By using a combination of a [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) to store existing drafts and an off-by-default configuration option, this should be a painless solution. I've tested it within the scope of my project but there may always be issues I haven't foreseen.

The diff is rather small and I fully expect that there will be features and use cases of Immer that enabling this config option may break. This is my first time looking behind the curtain of Immer, after all.