### PR TITLE
Make  `applyPatches` to accept  `readonly Patch[]`

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -941,7 +941,9 @@ function runBaseTest(name, autoFreeze, useStrictShallowCopy, useListener) {
 					if (canReferNonEnumerableProperty) s.foo.a++
 					if (useStrictShallowCopy) expect(isEnumerable(s, "foo")).toBeFalsy()
 				})
-				if (canReferNonEnumerableProperty) expect(nextState.foo).toBeTruthy()
+				if (canReferNonEnumerableProperty) {
+					expect(nextState.foo).toEqual({a: 2})
+				}
 				if (useStrictShallowCopy)
 					expect(isEnumerable(nextState, "foo")).toBeFalsy()
 				if (useStrictShallowCopy) expect(nextState.baz).toBeTruthy()

--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -8,7 +8,8 @@ import {
 	Immutable,
 	Immer,
 	enableMapSet,
-	enablePatches
+	enablePatches,
+	produceWithPatches
 } from "../src/immer"
 
 enableMapSet()
@@ -158,6 +159,20 @@ it("can apply patches", () => {
 			patches = p
 		}
 	)
+
+	expect(applyPatches({}, patches)).toEqual({x: 4})
+})
+
+it("can apply readonly patches", () => {
+	const [, patches]: readonly [
+		{
+			x: number
+		},
+		readonly Patch[],
+		readonly Patch[]
+	] = produceWithPatches({x: 3}, d => {
+		d.x++
+	})
 
 	expect(applyPatches({}, patches)).toEqual({x: 4})
 })

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -120,15 +120,11 @@ export class Immer implements ProducersFns {
 				this.produceWithPatches(state, (draft: any) => base(draft, ...args))
 		}
 
-		let patches: readonly Patch[], inversePatches: readonly Patch[]
-		const result = this.produce(
-			base,
-			recipe,
-			(p: readonly Patch[], ip: readonly Patch[]) => {
-				patches = p
-				inversePatches = ip
-			}
-		)
+		let patches: Patch[], inversePatches: Patch[]
+		const result = this.produce(base, recipe, (p: Patch[], ip: Patch[]) => {
+			patches = p
+			inversePatches = ip
+		})
 		return [result, patches!, inversePatches!]
 	}
 
@@ -171,7 +167,7 @@ export class Immer implements ProducersFns {
 		this.useStrictShallowCopy_ = value
 	}
 
-	applyPatches<T extends Objectish>(base: T, patches: Patch[]): T {
+	applyPatches<T extends Objectish>(base: T, patches: readonly Patch[]): T {
 		// If a patch replaces the entire state, take that replacement as base
 		// before applying patches
 		let i: number

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -120,11 +120,15 @@ export class Immer implements ProducersFns {
 				this.produceWithPatches(state, (draft: any) => base(draft, ...args))
 		}
 
-		let patches: Patch[], inversePatches: Patch[]
-		const result = this.produce(base, recipe, (p: Patch[], ip: Patch[]) => {
-			patches = p
-			inversePatches = ip
-		})
+		let patches: readonly Patch[], inversePatches: readonly Patch[]
+		const result = this.produce(
+			base,
+			recipe,
+			(p: readonly Patch[], ip: readonly Patch[]) => {
+				patches = p
+				inversePatches = ip
+			}
+		)
 		return [result, patches!, inversePatches!]
 	}
 

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -211,7 +211,7 @@ export function enablePatches() {
 		})
 	}
 
-	function applyPatches_<T>(draft: T, patches: Patch[]): T {
+	function applyPatches_<T>(draft: T, patches: readonly Patch[]): T {
 		patches.forEach(patch => {
 			const {path, op} = patch
 

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -68,10 +68,7 @@ export interface Patch {
 	value?: any
 }
 
-export type PatchListener = (
-	patches: readonly Patch[],
-	inversePatches: readonly Patch[]
-) => void
+export type PatchListener = (patches: Patch[], inversePatches: Patch[]) => void
 
 /** Converts `nothing` into `undefined` */
 type FromNothing<T> = T extends typeof NOTHING ? undefined : T
@@ -84,7 +81,7 @@ export type Produced<Base, Return> = Return extends void
 /**
  * Utility types
  */
-type PatchesTuple<T> = readonly [T, readonly Patch[], readonly Patch[]]
+type PatchesTuple<T> = readonly [T, Patch[], Patch[]]
 
 type ValidRecipeReturnType<State> =
 	| State

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -68,7 +68,10 @@ export interface Patch {
 	value?: any
 }
 
-export type PatchListener = (patches: Patch[], inversePatches: Patch[]) => void
+export type PatchListener = (
+	patches: readonly Patch[],
+	inversePatches: readonly Patch[]
+) => void
 
 /** Converts `nothing` into `undefined` */
 type FromNothing<T> = T extends typeof NOTHING ? undefined : T
@@ -81,7 +84,7 @@ export type Produced<Base, Return> = Return extends void
 /**
  * Utility types
  */
-type PatchesTuple<T> = readonly [T, Patch[], Patch[]]
+type PatchesTuple<T> = readonly [T, readonly Patch[], readonly Patch[]]
 
 type ValidRecipeReturnType<State> =
 	| State

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -24,7 +24,7 @@ const plugins: {
 			patches: Patch[],
 			inversePatches: Patch[]
 		): void
-		applyPatches_<T>(draft: T, patches: Patch[]): T
+		applyPatches_<T>(draft: T, patches: readonly Patch[]): T
 	}
 	MapSet?: {
 		proxyMap_<T extends AnyMap>(target: T, parent?: ImmerState): T


### PR DESCRIPTION
My main goal is for `applyPatches` to accept `readonly Patch[]` as there is no reason why it shouldn't accept it. If you think that other changes here are too risky (like returning `readonly Patch[]` from `produceWithPatches`) then I can revert those bits of this change. 