### PR TITLE
Add `./package.json` as an export entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/immer.legacy-esm.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/immer.d.ts",
       "import": "./dist/immer.mjs",


### PR DESCRIPTION
This will avoid breaking older tools that try to read `package.json` files from packages using package name instead of absolute path. 

Because when `exports` is set, accessing files that's not specified in the `exports` property is not allowed by node and it will throw a `ERR_PACKAGE_PATH_NOT_EXPORTED` error (rightly so).

This easily reproducible in the `node` repl.

This will throw 

```js
require.resolve('immer/package.json')
```

This will not throw

```js
require.resolve('./node_modules/immer/package.json')
```

![Screenshot 2024-03-20 at 10 50 05](https://github.com/immerjs/immer/assets/63876/31c5f44f-7ef8-4ebd-adac-100fee6b5a7e)


Something similar has been mentioned in this great article https://blog.isquaredsoftware.com/2023/08/esm-modernization-lessons/#issue-history by @markerikson (_sorry for the ping, feel free to ignore_) when he worked on modernizing `@reduxjs/toolkit` (_which depends on `immer` and this is how I found the issue_)

Similar issues in the wild on GitHub for `Package subpath './package.json' is not defined by "exports"` https://github.com/search?q=%22Package+subpath+%27.%2Fpackage.json%27+is+not+defined+by+%22exports%22%22&type=issues