### PR TITLE
chore: added update-pattern on how to replace & bulk update (nested) objects

### DIFF
--- a/website/docs/update-patterns.md
+++ b/website/docs/update-patterns.md
@@ -46,7 +46,7 @@ const updatedTodosObj = produce(todosObj, draft => {
 })
 ```
 
-Please keep in mind that when updating (nested) objects you should do so through mutation. Creating a new object and directly assigning it to a property in your immer draft object, will not work. This creates a new reference and does not update the existing object.
+Any time a nested draft field gets a new reference or value, produce() will finish applying the immutable update and return a new reference. If you tried to mutate, but the values remained the same, Immer will bail out and return the existing reference from produce()
 
 ### Array mutations
 

--- a/website/docs/update-patterns.md
+++ b/website/docs/update-patterns.md
@@ -35,7 +35,18 @@ const deletedTodosObj = produce(todosObj, draft => {
 const updatedTodosObj = produce(todosObj, draft => {
 	draft["id1"].done = true
 })
+
+// replace & update in bulk
+const updatedTodosObj = produce(todosObj, draft => {
+	Object.assign(draft, {
+		id1: {done: true, body: "Take out the trash"},
+		id2: {done: true, body: "Check Email"},
+		id3: {done: true, body: "Check Email"}
+	})
+})
 ```
+
+Please keep in mind that when updating (nested) objects you should do so through mutation. Creating a new object and directly assigning it to a property in your immer draft object, will not work. This creates a new reference and does not update the existing object.
 
 ### Array mutations
 

--- a/website/docs/update-patterns.md
+++ b/website/docs/update-patterns.md
@@ -41,7 +41,7 @@ const updatedTodosObj = produce(todosObj, draft => {
 	Object.assign(draft, {
 		id1: {done: true, body: "Take out the trash"},
 		id2: {done: true, body: "Check Email"},
-		id3: {done: true, body: "Check Email"}
+		id3: {done: true, body: "Feed my cat"}
 	})
 })
 ```


### PR DESCRIPTION
Add an update pattern that explains how to replace & update objects in bulk through mutation, the docs felt like they could use a little more explanation

Kudos to @markerikson for offering guidance and input