### PR TITLE
Prefix param with underscore to prevent unused param warning

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -204,7 +204,7 @@ export function freeze<T>(obj: any, deep: boolean = false): T {
 	if (deep)
 		// See #590, don't recurse into non-enumerable / Symbol properties when freezing
 		// So use Object.entries (only string-like, enumerables) instead of each()
-		Object.entries(obj).forEach(([key, value]) => freeze(value, true))
+		Object.entries(obj).forEach(([_key, value]) => freeze(value, true))
 	return obj
 }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -203,8 +203,8 @@ export function freeze<T>(obj: any, deep: boolean = false): T {
 	Object.freeze(obj)
 	if (deep)
 		// See #590, don't recurse into non-enumerable / Symbol properties when freezing
-		// So use Object.entries (only string-like, enumerables) instead of each()
-		Object.entries(obj).forEach(([_key, value]) => freeze(value, true))
+		// So use Object.values (only string-like, enumerables) instead of each()
+		Object.values(obj).forEach(value => freeze(value, true))
 	return obj
 }
 


### PR DESCRIPTION
Here's the current issue:
![image](https://github.com/user-attachments/assets/c1fed6a8-98cc-44fe-9ffc-349e2e84c96c)

Fixes https://github.com/immerjs/immer/issues/1144 by prefacing the unused param with `_`.
