### PR TITLE
fix: Freezing of Map values during finalization

### DIFF
--- a/__tests__/frozen.js
+++ b/__tests__/frozen.js
@@ -147,10 +147,12 @@ function runTests(name) {
 
 			const res = produce(base, draft => {
 				draft.set("a", 1)
+				draft.set("o", {b: 1})
 			})
 			expect(() => res.set("b", 2)).toThrowErrorMatchingSnapshot()
 			expect(() => res.clear()).toThrowErrorMatchingSnapshot()
 			expect(() => res.delete("b")).toThrowErrorMatchingSnapshot()
+			expect(Object.isFrozen(res.get("o"))).toBe(true)
 
 			// In draft, still editable
 			expect(produce(res, d => void d.set("a", 2))).not.toBe(res)

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -15,7 +15,8 @@ import {
 	getPlugin,
 	die,
 	revokeScope,
-	isFrozen
+	isFrozen,
+	isMap
 } from "../internal"
 
 export function processResult(result: any, scope: ImmerScope) {
@@ -151,7 +152,9 @@ function finalizeProperty(
 		if (
 			(!parentState || !parentState.scope_.parent_) &&
 			typeof prop !== "symbol" &&
-			Object.prototype.propertyIsEnumerable.call(targetObject, prop)
+			(isMap(targetObject)
+				? targetObject.has(prop)
+				: Object.prototype.propertyIsEnumerable.call(targetObject, prop))
 		)
 			maybeFreeze(rootScope, childValue)
 	}


### PR DESCRIPTION
## Findings
Map keys are not enumerable properties of the Map object, so the `propertyIsEnumerable` check does not apply to them.
This fails the check in `finalizeProperty` of `src/core/finalize.ts`.

## Changes
- Added a condition to detect `Map` objects and uses `Map.prototype.has` to check for key existence.

Fixes #1119