### PR TITLE
Update package.json exports for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,21 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/immer.d.ts",
-      "import": "./dist/immer.mjs",
-      "require": "./dist/cjs/index.js"
+      "react-native": {
+        "types": "./dist/immer.d.ts",
+        "default": "./dist/immer.legacy-esm.js"
+      },
+      "import": {
+        "types": "./dist/immer.d.ts",
+        "default": "./dist/immer.mjs"
+      },
+      "require": {
+        "types": "./dist/immer.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "jsnext:main": "dist/immer.mjs",
-  "react-native": "./dist/immer.legacy-esm.js",
   "source": "src/immer.ts",
   "types": "./dist/immer.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
Fixes zustand immer dependency for react-native, where `enableMapSet()` wasn't caught by zustand

https://github.com/pmndrs/zustand/discussions/3211#discussioncomment-14115032