### PR TITLE
Optimize Immer performance where possible

### DIFF
--- a/src/core/current.ts
+++ b/src/core/current.ts
@@ -21,18 +21,24 @@ function currentImpl(value: any): any {
 	if (!isDraftable(value) || isFrozen(value)) return value
 	const state: ImmerState | undefined = value[DRAFT_STATE]
 	let copy: any
+	let strict = true // Default to strict for compatibility
 	if (state) {
 		if (!state.modified_) return state.base_
 		// Optimization: avoid generating new drafts during copying
 		state.finalized_ = true
 		copy = shallowCopy(value, state.scope_.immer_.useStrictShallowCopy_)
+		strict = state.scope_.immer_.shouldUseStrictIteration(value)
 	} else {
 		copy = shallowCopy(value, true)
 	}
 	// recurse
-	each(copy, (key, childValue) => {
-		set(copy, key, currentImpl(childValue))
-	})
+	each(
+		copy,
+		(key, childValue) => {
+			set(copy, key, currentImpl(childValue))
+		},
+		strict
+	)
 	if (state) {
 		state.finalized_ = false
 	}

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -59,8 +59,11 @@ function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
 	const state: ImmerState = value[DRAFT_STATE]
 	// A plain object, might need freezing, might contain drafts
 	if (!state) {
-		each(value, (key, childValue) =>
-			finalizeProperty(rootScope, state, value, key, childValue, path)
+		each(
+			value,
+			(key, childValue) =>
+				finalizeProperty(rootScope, state, value, key, childValue, path),
+			rootScope.immer_.shouldUseStrictIteration(value)
 		)
 		return value
 	}
@@ -87,8 +90,19 @@ function finalize(rootScope: ImmerScope, value: any, path?: PatchPath) {
 			result.clear()
 			isSet = true
 		}
-		each(resultEach, (key, childValue) =>
-			finalizeProperty(rootScope, state, result, key, childValue, path, isSet)
+		each(
+			resultEach,
+			(key, childValue) =>
+				finalizeProperty(
+					rootScope,
+					state,
+					result,
+					key,
+					childValue,
+					path,
+					isSet
+				),
+			rootScope.immer_.shouldUseStrictIteration(resultEach)
 		)
 		// everything inside is frozen, we can freeze here
 		maybeFreeze(rootScope, result, false)

--- a/src/core/finalize.ts
+++ b/src/core/finalize.ts
@@ -114,6 +114,18 @@ function finalizeProperty(
 	rootPath?: PatchPath,
 	targetIsSet?: boolean
 ) {
+	if (childValue == null) {
+		return
+	}
+
+	if (typeof childValue !== "object" && !targetIsSet) {
+		return
+	}
+	const childIsFrozen = isFrozen(childValue)
+	if (childIsFrozen && !targetIsSet) {
+		return
+	}
+
 	if (process.env.NODE_ENV !== "production" && childValue === targetObject)
 		die(5)
 	if (isDraft(childValue)) {
@@ -136,13 +148,22 @@ function finalizeProperty(
 		targetObject.add(childValue)
 	}
 	// Search new objects for unfinalized drafts. Frozen objects should never contain drafts.
-	if (isDraftable(childValue) && !isFrozen(childValue)) {
+	if (isDraftable(childValue) && !childIsFrozen) {
 		if (!rootScope.immer_.autoFreeze_ && rootScope.unfinalizedDrafts_ < 1) {
 			// optimization: if an object is not a draft, and we don't have to
 			// deepfreeze everything, and we are sure that no drafts are left in the remaining object
 			// cause we saw and finalized all drafts already; we can stop visiting the rest of the tree.
 			// This benefits especially adding large data tree's without further processing.
 			// See add-data.js perf test
+			return
+		}
+		if (
+			parentState &&
+			parentState.base_ &&
+			parentState.base_[prop] === childValue &&
+			childIsFrozen
+		) {
+			// Object is unchanged from base - no need to process further
 			return
 		}
 		finalize(rootScope, childValue)

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -36,7 +36,7 @@ export type StrictMode = boolean | "class_only"
 export class Immer implements ProducersFns {
 	autoFreeze_: boolean = true
 	useStrictShallowCopy_: StrictMode = false
-	useStrictIteration_: boolean = false
+	useStrictIteration_: boolean = true
 
 	constructor(config?: {
 		autoFreeze?: boolean

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -31,20 +31,24 @@ interface ProducersFns {
 	produceWithPatches: IProduceWithPatches
 }
 
-export type StrictMode = boolean | "class_only";
+export type StrictMode = boolean | "class_only"
 
 export class Immer implements ProducersFns {
 	autoFreeze_: boolean = true
 	useStrictShallowCopy_: StrictMode = false
+	useStrictIteration_: boolean = false
 
 	constructor(config?: {
 		autoFreeze?: boolean
 		useStrictShallowCopy?: StrictMode
+		useStrictIteration?: boolean
 	}) {
 		if (typeof config?.autoFreeze === "boolean")
 			this.setAutoFreeze(config!.autoFreeze)
 		if (typeof config?.useStrictShallowCopy === "boolean")
 			this.setUseStrictShallowCopy(config!.useStrictShallowCopy)
+		if (typeof config?.useStrictIteration === "boolean")
+			this.setUseStrictIteration(config!.useStrictIteration)
 	}
 
 	/**
@@ -170,6 +174,20 @@ export class Immer implements ProducersFns {
 	 */
 	setUseStrictShallowCopy(value: StrictMode) {
 		this.useStrictShallowCopy_ = value
+	}
+
+	/**
+	 * Pass false to use faster iteration that skips non-enumerable properties
+	 * but still handles symbols for compatibility.
+	 *
+	 * By default, strict iteration is enabled (includes all own properties).
+	 */
+	setUseStrictIteration(value: boolean) {
+		this.useStrictIteration_ = value
+	}
+
+	shouldUseStrictIteration(obj: any): boolean {
+		return this.useStrictIteration_
 	}
 
 	applyPatches<T extends Objectish>(base: T, patches: readonly Patch[]): T {

--- a/src/immer.ts
+++ b/src/immer.ts
@@ -72,6 +72,16 @@ export const setUseStrictShallowCopy = /* @__PURE__ */ immer.setUseStrictShallow
 )
 
 /**
+ * Pass false to use ultra-fast iteration that only processes enumerable string properties.
+ * This skips symbols and non-enumerable properties for maximum performance.
+ *
+ * By default, strict iteration is enabled (includes all own properties).
+ */
+export const setUseStrictIteration = /* @__PURE__ */ immer.setUseStrictIteration.bind(
+	immer
+)
+
+/**
  * Apply an array of Immer patches to the first argument.
  *
  * This function is a producer, which means copy-on-write is in effect.

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -98,15 +98,23 @@ export function original(value: Drafted<any>): any {
 /**
  * Each iterates a map, set or array.
  * Or, if any other kind of object, all of its own properties.
- * Regardless whether they are enumerable or symbols
+ *
+ * @param obj The object to iterate over
+ * @param iter The iterator function
+ * @param strict When true (default), includes symbols and non-enumerable properties.
+ *               When false, uses ultra-fast iteration over only enumerable string properties.
  */
 export function each<T extends Objectish>(
 	obj: T,
-	iter: (key: string | number, value: any, source: T) => void
+	iter: (key: string | number, value: any, source: T) => void,
+	strict?: boolean
 ): void
-export function each(obj: any, iter: any) {
+export function each(obj: any, iter: any, strict: boolean = true) {
 	if (getArchtype(obj) === ArchType.Object) {
-		Reflect.ownKeys(obj).forEach(key => {
+		// If strict, we do a full iteration including symbols and non-enumerable properties
+		// Otherwise, we only iterate enumerable string properties for performance
+		const keys = strict ? Reflect.ownKeys(obj) : Object.keys(obj)
+		keys.forEach(key => {
 			iter(key, obj[key], obj)
 		})
 	} else {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -20,18 +20,29 @@ export function isDraft(value: any): boolean {
 	return !!value && !!value[DRAFT_STATE]
 }
 
+const isDraftableCache = new WeakMap<object, boolean>()
 /** Returns true if the given value can be drafted by Immer */
 /*#__PURE__*/
 export function isDraftable(value: any): boolean {
-	if (!value) return false
-	return (
+	// Fast path: primitives are never draftable
+	if (!value || typeof value !== "object") return false
+
+	// Now safe to check cache since we know value is an object
+	if (isDraftableCache.has(value)) {
+		return isDraftableCache.get(value)!
+	}
+
+	const result =
 		isPlainObject(value) ||
 		Array.isArray(value) ||
 		!!value[DRAFTABLE] ||
 		!!value.constructor?.[DRAFTABLE] ||
 		isMap(value) ||
 		isSet(value)
-	)
+
+	// Safe to cache since value is an object
+	isDraftableCache.set(value, result)
+	return result
 }
 
 const objectCtorString = Object.prototype.constructor.toString()


### PR DESCRIPTION
## Overview

(Effectively stacked on #1162 for Vitest and #1163 for the perf benchmark harness, but keeping this separate for ease of review.)

Per #1152 , I've been investigating Immer's loss of performance over the last several major versions.

Using the perf benchmark harness and CPU profiling, I was able to use AI to help identify a series of hotspots and slow functions, then try out various approaches to optimize them and check the results.  The benchmark numbers are noisier than I'd like, but as best as I can tell all of these are an improvement individually, and together.

The additional good news is that the changes in this PR are fairly small tweaks (per-function caching or early bailouts), and not major architectural changes.  So, these should be feasible to review and merge, and also it means that a larger architectural change might have additional wins.

## Optimizations

This PR contains several optimizations:

- `isPlainObject`:  This turned out to be a surprising hotspot right away.  The culprit seems to be the repeated constructor stringification, which is almost always the same reference with plain objects.  Using a `WeakMap` to cache that eliminated `isPlainObject` as a hotspot.
- `finalizeProperty`: Adding some early returns avoided running the rest of the logic in cases like primitives.
- `isDraftable`: another `WeakMap` cache, plus adding a fast bailout path
- `each`: ported the logic from the `faster-iteration-experiment` branch that uses `Object.keys()` instead of `Reflect.ownKeys()`, and added a new `setUseStrictIteration` option.  Currently it defaults to `true` to maintain the existing behavior.

## Perf Results

If I run the benchmark with these changes, the relative results are:

```
  add: vanilla (freeze: true)
   1.01x faster than add: vanilla (freeze: false)
   23.59x faster than add: immer10Perf (freeze: true)
   32.58x faster than add: immer7 (freeze: false)
   35.79x faster than add: immer10 (freeze: false)
   36.23x faster than add: immer10Perf (freeze: false)
   39.12x faster than add: immer9 (freeze: false)
   42.62x faster than add: immer7 (freeze: true)
   43.01x faster than add: immer9 (freeze: true)
   44.97x faster than add: immer10 (freeze: true)
   173.72x faster than add: immer8 (freeze: false)
   185.97x faster than add: immer8 (freeze: true)
   
  remove: vanilla (freeze: true)
   1.03x faster than remove: vanilla (freeze: false)
   1279.15x faster than remove: immer7 (freeze: true)
   1318.47x faster than remove: immer10 (freeze: true)
   1450.17x faster than remove: immer9 (freeze: true)
   1519.93x faster than remove: immer10Perf (freeze: true)
   1786.77x faster than remove: immer7 (freeze: false)
   1979.2x faster than remove: immer9 (freeze: false)
   2282.56x faster than remove: immer10Perf (freeze: false)
   2297.47x faster than remove: immer8 (freeze: true)
   2309.37x faster than remove: immer10 (freeze: false)
   2679.58x faster than remove: immer8 (freeze: false)

  filter: vanilla (freeze: true)
   1.94x faster than filter: vanilla (freeze: false)
   154.58x faster than filter: immer7 (freeze: true)
   166.28x faster than filter: immer10 (freeze: true)
   174.82x faster than filter: immer9 (freeze: true)
   195.95x faster than filter: immer10Perf (freeze: true)
   250.02x faster than filter: immer7 (freeze: false)
   269.69x faster than filter: immer8 (freeze: true)
   299.04x faster than filter: immer9 (freeze: false)
   344.94x faster than filter: immer10 (freeze: false)
   356x faster than filter: immer10Perf (freeze: false)
   438.49x faster than filter: immer8 (freeze: false)

  update: vanilla (freeze: true)
   1.03x faster than update: vanilla (freeze: false)
   3.37x faster than update: immer10Perf (freeze: true)
   5.94x faster than update: immer7 (freeze: false)
   6.53x faster than update: immer10Perf (freeze: false)
   6.55x faster than update: immer10 (freeze: false)
   6.73x faster than update: immer10 (freeze: true)
   6.96x faster than update: immer7 (freeze: true)
   7.07x faster than update: immer9 (freeze: false)
   7.81x faster than update: immer9 (freeze: true)
   32x faster than update: immer8 (freeze: true)
   34.84x faster than update: immer8 (freeze: false)

  concat: vanilla (freeze: true)
   1.02x faster than concat: vanilla (freeze: false)
   1.08x faster than concat: immer10 (freeze: false)
   1.13x faster than concat: immer7 (freeze: false)
   1.21x faster than concat: immer9 (freeze: false)
   1.21x faster than concat: immer8 (freeze: false)
   2.27x faster than concat: immer10Perf (freeze: false)
   26.48x faster than concat: immer7 (freeze: true)
   29.2x faster than concat: immer9 (freeze: true)
   31.7x faster than concat: immer10 (freeze: true)
   32.31x faster than concat: immer10Perf (freeze: true)
   112.02x faster than concat: immer8 (freeze: true)
```

If I run `read-cpuprofile.js` on the generated CPU profile, the latest run gives me:

```
Total CPU samples analyzed: 81072517

Version breakdown:
  v7: 22168131 samples (27.3%)
  v10: 19730629 samples (24.3%)
  v9: 12176135 samples (15.0%)
  unknown: 11139931 samples (13.7%)
  v8: 6650122 samples (8.2%)
  v10Perf: 5466330 samples (6.7%)
  mitata: 1916438 samples (2.4%)
  application: 1281600 samples (1.6%)
  benchmark: 326422 samples (0.4%)
  source-map-support: 216779 samples (0.3%) 
```

So, the numbers are fuzzier and not as fast as I'd like, but this _appears_ to be a meaningful improvement - `v10Perf` takes up much less time in the benchmarks than `v10`.

## Other Attempted Changes

You had previously commented:

> Two high level thoughts jump to mind as to causes:
> 
> 1. The reflection method we used changed over time, mostly for correctness reasons around edge cases like non-enumerable, getters, or inherited fields. In my benchmarks it didn't change much, but yours might be more accurate (or V8 has changed meaningfully). However, this is for uncommon scenarios (especially icmw Redux), so it might be worth to introduce a "sloppy" mode where things would be faster.
> 
> 2. Freezing is expensive, but primarily done to eliminate branch traversals the next time is drafted. Originally immer didn't deeply prune, but now we do to find drafts that would otherwise accidentally stay around in a case like `draft.x = [draft.y]` (originally Immer didn't traverse into "new" objects coming from the "outside" like the new array here). However, I want to explore the option to "mark committed / final" instead of "revoke" the draft proxies. Because we know all proxies involved in a recipe, that means that we don't need to scan or rewrite the final tree, at the costs leaving proxies around in the final state. That shouldn't affect semantics, but in the debugger you'd see proxies.

I tried to implement a couple larger architectural changes based on these as well:

- I tried using a queue to do a breadth-first iteration of the tree rather than the recursive `finalize()` + `finalizeProperty()` sequences. This was a complete non-improvement - literally identical numbers of function calls and equal or worse execution time.
- I also tried showing this "mark committed" paragraph to Claude and having it try to figure out what that might involve architecturally and implement it.  It got bogged down with test failures and still calling the existing `finalize()` method with no actual improvement, and I eventually gave up.