### PR TITLE
Add second large object test to check v8 non-fast properties

### DIFF
--- a/perf-testing/immutability-benchmarks.mjs
+++ b/perf-testing/immutability-benchmarks.mjs
@@ -180,11 +180,12 @@ const actions = {
 	remove,
 	filter,
 	update,
-	updateLargeObject1,
-	updateLargeObject2,
 	concat,
 	mapNested,
 	// dash-named fields to improve readability in benchmark results
+
+	"update-largeObject1": updateLargeObject1,
+	"update-largeObject2": updateLargeObject2,
 	"update-high": updateHigh,
 	"update-multiple": updateMultiple,
 	"remove-high": removeHigh,
@@ -621,8 +622,8 @@ function createBenchmarks() {
 		"update-high",
 		"remove",
 		"remove-high",
-		"updateLargeObject1",
-		"updateLargeObject2"
+		"update-largeObject1",
+		"update-largeObject2"
 	]
 	for (const action of reuseActions) {
 		summary(function() {
@@ -1216,13 +1217,6 @@ function printOverallVersionRankings(versionScores) {
 		return
 	}
 
-	console.log(
-		"\nMethodology: Lower geometric mean = better overall performance"
-	)
-	console.log(
-		"(Geometric mean is standard for benchmarking as it handles multiplicative performance differences)"
-	)
-
 	console.log("\n┌──────┬─────────────────────┬─────────────────┬───────────┐")
 	console.log("│ Rank │ Version             │ Geometric Mean  │ Scenarios │")
 	console.log("├──────┼─────────────────────┼─────────────────┼───────────┤")
@@ -1241,22 +1235,6 @@ function printOverallVersionRankings(versionScores) {
 	}
 
 	console.log("└──────┴─────────────────────┴─────────────────┴───────────┘")
-
-	// Highlight top performers
-	if (versionScores.length >= 3) {
-		console.log("\nTop Overall Performers:")
-		for (let i = 0; i < Math.min(10, versionScores.length); i++) {
-			const score = versionScores[i]
-			const [versionName, freezeIndicator] = score.version.split("|")
-			const shortName = shortenVersionName(versionName)
-			console.log(
-				`  ${i +
-					1}. ${shortName} (${freezeIndicator}) - ${score.geometricMean.toFixed(
-					2
-				)}x average`
-			)
-		}
-	}
 }
 
 function printBenchmarkSummaryTable(benchmarks) {


### PR DESCRIPTION
This PR:

- Adds a second "large object" benchmark test with 3000 properties, as experimentation has showed there's a performance cliff in v8 around 1000 properties (likely due to its "fast properties" implementation switching behavior)
- Tweaks some of the output formatting (removed some useless lines, fixed some wrapping)

Performance on `main` as of this PR (with just the perf tweaks from #1164 merged), compared to the previous 10.1.x releases:

**Strict iteration (current default in 10.2)**

```
✓ immer10Perf shows an average 7.6% performance improvement over immer10

┌─────────────────────┬──────────────┬──────────────┬─────────────┐
│ Scenario            │ immer10      │ immer10Perf  │ Improvement │
├─────────────────────┼──────────────┼──────────────┼─────────────┤
│ mixed-sequence      │        9.4ms │        6.7ms │      +28.5% │
│ update-largeObject1 │       15.2ms │       12.5ms │      +17.8% │
│ update-largeObject2 │        2.1ms │        1.8ms │      +16.2% │
│ update-reuse        │        8.6ms │        7.2ms │      +16.1% │
│ remove-high-reuse   │        8.2ms │        7.0ms │      +15.2% │
│ update-largeObject1 │      591.1µs │      521.1µs │      +11.8% │
│ remove-reuse        │        8.5ms │        7.5ms │      +11.3% │
│ update-largeObject2 │       27.8ms │       24.7ms │      +11.2% │
│ rtkq-sequence       │       28.0ms │       25.1ms │      +10.3% │
│ update-high-reuse   │        8.8ms │        7.9ms │       +9.7% │
│ update              │       73.3µs │       67.2µs │       +8.2% │
│ update-multiple     │       85.4µs │       79.3µs │       +7.1% │
│ concat              │      173.1µs │      161.9µs │       +6.5% │
│ remove-high         │      167.4µs │      160.9µs │       +3.8% │
│ sortById-reverse    │      183.0µs │      176.1µs │       +3.8% │
│ filter              │       97.7µs │       94.3µs │       +3.5% │
│ add                 │       70.3µs │       70.0µs │       +0.3% │
│ mapNested           │      175.8µs │      176.0µs │       -0.1% │
│ remove              │      185.1µs │      192.9µs │       -4.3% │
│ reverse-array       │      160.9µs │      174.4µs │       -8.4% │
│ update-high         │      131.0µs │      142.2µs │       -8.5% │
└─────────────────────┴──────────────┴──────────────┴─────────────┘
```

**Loose iteration (opt-in now, default in v11)**

```

✓ immer10Perf shows an average 20.7% performance improvement over immer10

┌─────────────────────┬──────────────┬──────────────┬─────────────┐
│ Scenario            │ immer10      │ immer10Perf  │ Improvement │
├─────────────────────┼──────────────┼──────────────┼─────────────┤
│ update-reuse        │        9.3ms │        4.4ms │      +52.4% │
│ mixed-sequence      │        8.7ms │        4.7ms │      +46.7% │
│ update-high-reuse   │       11.3ms │        6.1ms │      +45.8% │
│ remove-reuse        │       12.2ms │        6.8ms │      +44.4% │
│ remove-high-reuse   │        8.6ms │        5.3ms │      +38.6% │
│ update-largeObject1 │       15.9ms │       10.6ms │      +33.3% │
│ rtkq-sequence       │       31.9ms │       22.4ms │      +29.9% │
│ concat              │      157.9µs │      115.8µs │      +26.6% │
│ update-largeObject2 │       30.1ms │       22.1ms │      +26.4% │
│ add                 │       83.2µs │       65.5µs │      +21.4% │
│ update-largeObject1 │      572.2µs │      462.1µs │      +19.2% │
│ update-largeObject2 │        2.0ms │        1.7ms │      +16.5% │
│ filter              │      107.5µs │       90.3µs │      +16.0% │
│ update              │       70.5µs │       59.3µs │      +15.8% │
│ update-multiple     │       85.0µs │       72.0µs │      +15.3% │
│ update-high         │      131.9µs │      131.6µs │       +0.3% │
│ sortById-reverse    │      188.6µs │      189.0µs │       -0.2% │
│ mapNested           │      171.6µs │      173.9µs │       -1.4% │
│ reverse-array       │      170.1µs │      176.0µs │       -3.5% │
│ remove              │      173.0µs │      179.1µs │       -3.5% │
│ remove-high         │      148.0µs │      154.9µs │       -4.6% │
└─────────────────────┴──────────────┴──────────────┴─────────────┘
```