### PR TITLE
Re-add isDraftable check to skip freezing non-obj values

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -2677,6 +2677,29 @@ function runBaseTest(name, autoFreeze, useStrictShallowCopy, useListener) {
 			})
 
 		autoFreeze &&
+			test("issue #1190 / #1192 - should not freeze non-draftable objects (class instances and typed arrays)", () => {
+				class MutableClass {
+					value = 5
+				}
+
+				const state = {
+					someValue: 5,
+					mutableClass: new MutableClass(),
+					typedArray: new Uint8Array(10)
+				}
+
+				expect(() => {
+					// Should not throw when producing with autoFreeze enabled
+					const result = produce(state, draft => {
+						draft.someValue = 6
+					})
+
+					// Verify the non-draftable class instance is not frozen
+					state.mutableClass.value = 6
+				}).not.toThrow()
+			})
+
+		autoFreeze &&
 			test("issue #469, state not frozen", () => {
 				const project = produce(
 					{

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -243,7 +243,7 @@ export function shallowCopy(base: any, strict: StrictMode) {
  */
 export function freeze<T>(obj: T, deep?: boolean): T
 export function freeze<T>(obj: any, deep: boolean = false): T {
-	if (isFrozen(obj) || isDraft(obj)) return obj
+	if (isFrozen(obj) || isDraft(obj) || !isDraftable(obj)) return obj
 	if (getArchtype(obj) > 1 /* Map or Set */) {
 		O.defineProperties(obj, {
 			set: dontMutateMethodOverride,


### PR DESCRIPTION
This PR:

- Re-adds the `!isDraftable(obj)` check to `freeze()` to fix the regression from #1183 and avoid freezing non-draftable objects

Fixes #1190
Fixes #1192 