### PR TITLE
chore: regression tests for fixed issue #916

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -198,6 +198,69 @@ describe("applyPatches", () => {
 	})
 })
 
+describe("#916 nested patches with moved child draft", () => {
+	const makeBaseState = () => ({
+		id: 0,
+		type: "root",
+		children: [{id: 2, type: "node", value: "A"}]
+	})
+
+	const makeRootWithGroup = groupName => ({
+		id: 0,
+		type: "root",
+		children: [
+			{
+				id: 3,
+				children: [{id: 2, type: "node", value: "A"}],
+				groupName
+			}
+		]
+	})
+
+	function runNestedPatchScenario() {
+		let nestedPatches = []
+		const [nextState] = produceWithPatches(makeBaseState(), draft => {
+			const node = draft.children[0]
+			draft.children.splice(0, 1) // remove node from root
+
+			const group = {id: 3, children: [node], groupName: ""} // new group
+			draft.children.splice(0, 0, group) // add group to root
+
+			const [, patches] = produceWithPatches(draft, inner => {
+				const value = inner.children[0].children[0].value
+				inner.children[0].groupName = value + " Group"
+			})
+
+			nestedPatches = patches
+			applyPatches(draft, patches)
+		})
+
+		return {nextState, patches: nestedPatches}
+	}
+
+	it("#916 nested patches with moved child draft", () => {
+		const {nextState, patches} = runNestedPatchScenario()
+
+		expect(patches).toEqual(
+			expect.arrayContaining([
+				{
+					op: "replace",
+					path: ["children", 0, "groupName"],
+					value: "A Group"
+				}
+			])
+		)
+		expect(nextState).toEqual(makeRootWithGroup("A Group"))
+	})
+
+	it("#916 patches apply on non-draft base", () => {
+		const {patches} = runNestedPatchScenario()
+		expect(applyPatches(makeRootWithGroup(""), patches)).toEqual(
+			makeRootWithGroup("A Group")
+		)
+	})
+})
+
 // New macro-style test
 runPatchTests(
 	"simple assignment - 1",


### PR DESCRIPTION
Hey, first time contributor here! I've been a long term user (directly and indirectly) of immer so I'm really happy to contribute back.

I'm starting off with a relatively simple addition of regression tests verifying that issue #916 has been addressed.

This issue was originally fixed in [PR 917](https://github.com/immerjs/immer/pull/917), landing in `v9.0.19` of immer. You should find that bumping the version of immer to that version in the issue's [referenced codesandbox](https://codesandbox.io/s/minimal-repro-forked-xvb93p) will demonstrate it is no longer an issue.