### PR TITLE
fix: remove invalid curried producer type

### DIFF
--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -187,6 +187,9 @@ describe("curried producer", () => {
 			let foo = produce((s: State, a: number, b: number) => {})
 			assert(foo, _ as Recipe)
 			foo(_ as State, 1, 2)
+
+			// @ts-expect-error
+			foo(undefined, 1, 2)
 		}
 
 		// Using argument parameters:
@@ -743,6 +746,13 @@ it("infers curried", () => {
 		const n = f(base as ROState)
 		assert(n, _ as ROState) // yay!
 	}
+	{
+		// explicitly use generic, but curried
+		const f = produce<ROState>(draft => {
+			draft.count++
+		})
+		assert(f, _ as (state: ROState) => ROState)
+	}
 }
 
 it("allows for mixed property value types", () => {
@@ -757,4 +767,23 @@ it("allows for mixed property value types", () => {
 			draft.testObjectOrNull.testProperty = 5
 		}
 	})
+})
+
+it("#877 - produce with typed state generic requires initial state", () => {
+	const reducerNoInitial = produce<{count: number}, [{type: "inc"}]>(
+		(draft, action: {type: "inc"}) => {
+			if (action.type === "inc") draft.count++
+		}
+	)
+	const reducer = produce<{count: number}, [{type: "inc"}]>(
+		(draft, action: {type: "inc"}) => {
+			if (action.type === "inc") draft.count++
+		},
+		{count: 0}
+	)
+
+	expect(reducer({count: 0}, {type: "inc"})).toEqual({count: 1})
+	expect(reducer(undefined, {type: "inc"})).toEqual({count: 1})
+	// @ts-expect-error runtime error without initial state
+	expect(() => reducerNoInitial(undefined, {type: "inc"})).toThrow()
 })

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -187,12 +187,6 @@ export interface IProduce {
 	>
 
 	/** Curried producer that infers curried from the State generic, which is explicitly passed in.  */
-	<State>(
-		recipe: (
-			state: Draft<State>,
-			initialState: State
-		) => ValidRecipeReturnType<State>
-	): (state?: State) => State
 	<State, Args extends any[]>(
 		recipe: (
 			state: Draft<State>,


### PR DESCRIPTION
The removed curried producer type aims to resolve issues #831 and #877.

There's a couple of issues with the type, hence its removal in favour of the existing types:
 - It expects an `initialState` argument to be passed **within** the recipe itself, which isn't a valid use case
 - It allows state to be `undefined` even if the user has passed in a state generic type, which loosens inference