### PR TITLE
fix: update current and original typings to assert draft value is unwrapped

### DIFF
--- a/__tests__/type-external.ts
+++ b/__tests__/type-external.ts
@@ -1,5 +1,6 @@
 import {isType, JSONArray, JSONObject, JSONTypes} from "type-plus"
 import {Draft} from "../src/types/types-external"
+import {createDraft, current, original} from "../src/immer"
 
 describe("Draft<T>", () => {
 	test("can use JSONTypes as T", () => {
@@ -15,5 +16,29 @@ describe("Draft<T>", () => {
 	it("can use Tuple as T", () => {
 		type A = Draft<[string, number, JSONArray, JSONObject]>
 		isType.equal<true, [string, number, JSONArray, JSONObject], A>()
+	})
+})
+
+describe("current() typings", () => {
+	test("returns non-draft type from a draft input", () => {
+		type Base = Readonly<{a: boolean}>
+		const base: Base = {a: true}
+		const draft = createDraft<Base>(base)
+		const result = current(draft)
+
+		// Readonly base ensures Draft<Base> differs, exposing current()'s typing.
+		isType.equal<true, Base, typeof result>()
+	})
+})
+
+describe("original() typings", () => {
+	test("returns non-draft type from a draft input", () => {
+		type Base = Readonly<{a: boolean}>
+		const base: Base = {a: true}
+		const draft = createDraft<Base>(base)
+		const result = original(draft)
+
+		// Readonly base ensures Draft<Base> differs, exposing original()'s typing.
+		isType.equal<true, Base, typeof result>()
 	})
 })

--- a/src/core/current.ts
+++ b/src/core/current.ts
@@ -1,5 +1,6 @@
 import {
 	die,
+	Draft,
 	isDraft,
 	shallowCopy,
 	each,
@@ -11,8 +12,8 @@ import {
 } from "../internal"
 
 /** Takes a snapshot of the current state of a draft and finalizes it (but without freezing). This is a great utility to print the current state during debugging (no Proxies in the way). The output of current can also be safely leaked outside the producer. */
-export function current<T>(value: T): T
-export function current(value: any): any {
+export function current<T>(value: Draft<T>): T
+export function current(value: Draft<any>): any {
 	if (!isDraft(value)) die(10, value)
 	return currentImpl(value)
 }

--- a/src/core/immerClass.ts
+++ b/src/core/immerClass.ts
@@ -151,7 +151,7 @@ export class Immer implements ProducersFns {
 
 	createDraft<T extends Objectish>(base: T): Draft<T> {
 		if (!isDraftable(base)) die(8)
-		if (isDraft(base)) base = current(base)
+		if (isDraft(base)) base = current(base as Draft<T>)
 		const scope = enterScope(this)
 		const proxy = createProxy(scope, base, undefined)
 		proxy[DRAFT_STATE].isManual_ = true

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -2,7 +2,7 @@ import {
 	DRAFT_STATE,
 	DRAFTABLE,
 	Objectish,
-	Drafted,
+	Draft,
 	AnyObject,
 	AnyMap,
 	AnySet,
@@ -66,8 +66,8 @@ export function isPlainObject(value: any): boolean {
 
 /** Get the underlying object that is represented by the given draft */
 /*#__PURE__*/
-export function original<T>(value: T): T | undefined
-export function original(value: Drafted<any>): any {
+export function original<T>(value: Draft<T>): T
+export function original(value: Draft<any>): any {
 	if (!isDraft(value)) die(15, value)
 	return value[DRAFT_STATE].base_
 }


### PR DESCRIPTION
Resolves #896 

`current` and `original` typings have been updated to ensure that the passed in value is a `draft` type, with the returned type being the unwrapped (non-draft) equivalent.