### PR TITLE
fix: correct curried produceWithPatches return type

### DIFF
--- a/__tests__/produce.ts
+++ b/__tests__/produce.ts
@@ -755,6 +755,41 @@ it("infers curried", () => {
 		})
 		assert(f, _ as (state: ROState) => ROState)
 	}
+	// produceWithPatches should infer the same state type as produce (#1045),
+	// just wrapped in the [state, patches, inversePatches] tuple
+	{
+		// curried
+		const f = produceWithPatches((state: State) => {
+			state.count++
+		})
+		assert(
+			f,
+			_ as (state: Immutable<State>) => readonly [State, Patch[], Patch[]]
+		)
+	}
+	{
+		// curried, with extra argument
+		const f = produceWithPatches((state: State, delta: number) => {
+			state.count += delta
+		})
+		assert(
+			f,
+			_ as (
+				state: Immutable<State>,
+				delta: number
+			) => readonly [State, Patch[], Patch[]]
+		)
+	}
+	{
+		// explicitly use generic, but curried
+		const f = produceWithPatches<State, [number]>((state, delta) => {
+			state.count += delta
+		})
+		assert(
+			f,
+			_ as (state: State, delta: number) => readonly [State, Patch[], Patch[]]
+		)
+	}
 }
 
 it("allows for mixed property value types", () => {

--- a/src/types/types-external.ts
+++ b/src/types/types-external.ts
@@ -234,6 +234,22 @@ export interface IProduce {
 export interface IProduceWithPatches {
 	// Types copied from IProduce, wrapped with PatchesTuple
 	<Recipe extends AnyFunc>(recipe: Recipe): InferCurriedFromRecipe<Recipe, true>
+
+	/** Curried producer that infers curried from the State generic, which is explicitly passed in.  */
+	<State, Args extends any[]>(
+		recipe: (
+			state: Draft<State>,
+			...args: Args
+		) => ValidRecipeReturnType<State>,
+		initialState: State
+	): (state?: State, ...args: Args) => PatchesTuple<State>
+	<State>(
+		recipe: (state: Draft<State>) => ValidRecipeReturnType<State>
+	): (state: State) => PatchesTuple<State>
+	<State, Args extends any[]>(
+		recipe: (state: Draft<State>, ...args: Args) => ValidRecipeReturnType<State>
+	): (state: State, ...args: Args) => PatchesTuple<State>
+
 	<State, Recipe extends Function>(
 		recipe: Recipe,
 		initialState: State


### PR DESCRIPTION
## Summary

The **curried** forms of `produceWithPatches` infer the wrong type, while the equivalent `produce` forms work correctly (issue #1045):

- `produceWithPatches(recipe)` returns the **draft** type (`WritableDraft<State>`) in the result tuple instead of the original `State`.
- The explicit-generic form `produceWithPatches<State, Args>(recipe)` resolves to `never` and is not even callable.

```ts
import {produce, produceWithPatches, Draft} from "immer"

type N = {count: number}

// produce: curried result is correctly typed as N
const a = produce((d: Draft<N>, m: number) => { d.count += m })(state, 1)
//    ^? N

// produceWithPatches: result[0] is WritableDraft<N>, not N
const b = produceWithPatches((d: Draft<N>, m: number) => { d.count += m })(state, 1)
//    ^? [WritableDraft<N>, Patch[], Patch[]]

// produceWithPatches<N, [number]>(...) is `never` / not callable
const c = produceWithPatches<N, [number]>((d, m) => { d.count += m })
//    ^? never
```

## Root cause

`IProduceWithPatches` is documented as *"Types copied from IProduce, wrapped with PatchesTuple"*, but the copy is incomplete: it is missing the `<State, Args>` curried overloads that `IProduce` has. Without them, curried calls fall through to `InferCurriedFromRecipe`, whose return type is the draft state (`DraftState`) rather than the original `State`, and the explicit-generic form has no matching overload at all (hence `never`).

## Fix

Mirror the three `<State, Args>` curried overloads from `IProduce` into `IProduceWithPatches`, wrapping their return type in `PatchesTuple`. The non-curried and initial-state forms are unchanged.

## Tests

Added type-level assertions to `__tests__/produce.ts` (alongside the existing curried `produce` assertions) covering all three curried forms. These fail on `main` and pass with the fix.

- `vitest run` — all 3651 tests pass
- `vitest run --config vitest.config.build.ts` (build/`.d.ts` tests) — all pass
- `yarn build` succeeds and the new overloads are emitted into `dist/immer.d.ts`

Closes #1045