### PR TITLE
fix: throw proper immer error when applyPatches path traverses null

### DIFF
--- a/__tests__/patch.js
+++ b/__tests__/patch.js
@@ -1596,3 +1596,12 @@ describe("RTK-5159: Patch path truncation bug", () => {
 		expect(patches[0].path).toEqual(["queries", "queryKey", "data", "items", 1])
 	})
 })
+test("applyPatches throws proper immer error when intermediate path value is null", () => {
+	// isObjectish(null) === true (typeof null === "object"), so the null check
+	// inside applyPatches_ was missing; navigating into null threw a native
+	// TypeError instead of immer's own "path doesn't resolve" error.
+	const isProd = process.env.NODE_ENV === "production"
+	expect(() => {
+		applyPatches({a: null}, [{op: "add", path: ["a", "b"], value: 1}])
+	}).toThrow(isProd ? "18" : "Cannot apply patch, path doesn't resolve: a/b")
+})

--- a/src/plugins/patches.ts
+++ b/src/plugins/patches.ts
@@ -345,7 +345,8 @@ export function enablePatches() {
 					die(errorOffset + 3)
 				if (isFunction(base) && p === PROTOTYPE) die(errorOffset + 3)
 				base = get(base, p)
-				if (!isObjectish(base)) die(errorOffset + 2, path.join("/"))
+				if (base === null || !isObjectish(base))
+					die(errorOffset + 2, path.join("/"))
 			}
 
 			const type = getArchtype(base)


### PR DESCRIPTION
## Bug

`applyPatches` throws a native `TypeError` instead of immer's own error when a patch path navigates through a `null` intermediate value.

**Root cause:** `isObjectish` is implemented as `typeof target === "object"`. Because `typeof null === "object"` in JavaScript, `isObjectish(null)` returns `true`. The guard inside `applyPatches_` that is supposed to catch non-navigable intermediates therefore lets `null` slip through. The next iteration (or the post-loop `getArchtype` call) then does `null[DRAFT_STATE]` and crashes with:

```
TypeError: Cannot read properties of null (reading 'Symbol(immer-state)')
```

instead of immer error 18:

```
Cannot apply patch, path doesn't resolve: a/b
```

## Fix

Add an explicit `base === null` check alongside `!isObjectish(base)` in the path-traversal loop of `applyPatches_` (src/plugins/patches.ts):

```diff
-if (!isObjectish(base)) die(errorOffset + 2, path.join("/"))
+if (base === null || !isObjectish(base)) die(errorOffset + 2, path.join("/"))
```

## Verification

```
yarn test:src
# Test Files  22 passed (22)
# Tests  3652 passed | 8 skipped (3660)
```

New test added in `__tests__/patch.js`:
- `applyPatches({a: null}, [{op: 'add', path: ['a', 'b'], value: 1}])` now throws with message `"Cannot apply patch, path doesn't resolve: a/b"`

> This PR was prepared with AI assistance.