### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -15,6 +15,7 @@ Immer can be installed as a direct dependency, and will work in any ES5 environm
 
 - Yarn: `yarn add immer`
 - NPM: `npm install immer`
+- Deno: `deno install immer`
 - CDN: Exposed global is `immer`
   - Unpkg: `<script src="https://unpkg.com/immer"></script>`
   - JSDelivr: `<script src="https://cdn.jsdelivr.net/npm/immer"></script>`


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list Yarn and NPM, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install immer
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install immer`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
