### PR TITLE
fix: draft relocated base refs after reverse/sort in array-methods plugin

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -8,7 +8,8 @@ import {
 	immerable,
 	enablePatches,
 	enableMapSet,
-	enableArrayMethods
+	enableArrayMethods,
+	applyPatches
 } from "../src/immer"
 
 import {
@@ -354,6 +355,37 @@ function runBaseTest(
 					})
 					expect(nextState).not.toBe(baseState)
 					expect(nextState).toEqual([{value: 1}, {value: 2}, {value: 3}])
+				})
+
+				it("mutating an element after reverse() does not mutate the base", () => {
+					const reordered = {id: 3}
+					const baseState = [{id: 1}, {id: 2}, reordered]
+					const nextState = produce(baseState, s => {
+						s.reverse()
+						// After reverse, the element at index 0 is the relocated base
+						// object. It must be drafted, otherwise writing to it mutates base.
+						expect(isDraft(s[0])).toBe(true)
+						s[0].id = 99
+					})
+					expect(baseState).toEqual([{id: 1}, {id: 2}, {id: 3}])
+					expect(reordered).toEqual({id: 3})
+					expect(nextState).toEqual([{id: 99}, {id: 2}, {id: 1}])
+				})
+
+				it("mutating an element after sort() does not mutate the base", () => {
+					const baseState = [{value: 3}, {value: 1}, {value: 2}]
+					const [nextState, patches, inverse] = produceWithPatches(
+						baseState,
+						s => {
+							s.sort((a, b) => a.value - b.value)
+							expect(isDraft(s[0])).toBe(true)
+							s[0].value = 99
+						}
+					)
+					expect(baseState).toEqual([{value: 3}, {value: 1}, {value: 2}])
+					expect(nextState).toEqual([{value: 99}, {value: 2}, {value: 3}])
+					expect(applyPatches(baseState, patches)).toEqual(nextState)
+					expect(applyPatches(nextState, inverse)).toEqual(baseState)
 				})
 
 				describe("push()", () => {

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -44,6 +44,7 @@ export interface ProxyArrayState extends ProxyBaseState {
 	draft_: Drafted<AnyArray, ProxyArrayState>
 	operationMethod?: string
 	allIndicesReassigned_?: boolean
+	baseRefs_?: Set<any>
 }
 
 type ProxyState = ProxyObjectState | ProxyArrayState
@@ -172,7 +173,10 @@ export const objectTraps: ProxyHandler<ProxyState> = {
 		}
 		// Check for existing draft in modified state.
 		// Assigned values are never drafted. This catches any drafts we created, too.
-		if (value === peek(state.base_, prop)) {
+		if (
+			value === peek(state.base_, prop) ||
+			isRelocatedBaseRef(state, prop, value)
+		) {
 			prepareCopy(state)
 			// Ensure array keys are always numbers
 			const childKey = state.type_ === ArchType.Array ? +(prop as string) : prop
@@ -330,6 +334,25 @@ function peek(draft: Drafted, prop: PropertyKey) {
 	const state = draft[DRAFT_STATE]
 	const source = state ? latest(state) : draft
 	return source[prop]
+}
+
+// Reordering array methods (reverse, sort) from the array-methods plugin run
+// natively on `copy_`, which still holds raw base references. This relocates an
+// un-drafted base object to a position where it no longer matches `base_[prop]`,
+// so the normal positional check above misses it and the get trap would hand back
+// the raw base object, breaking the guarantee that the base state is never mutated.
+// Detect such a relocated base reference so it is drafted before being exposed.
+function isRelocatedBaseRef(state: ImmerState, prop: PropertyKey, value: any) {
+	if (
+		state.type_ !== ArchType.Array ||
+		!(state as ProxyArrayState).allIndicesReassigned_ ||
+		state.assigned_?.get(prop) ||
+		!isDraftable(value) ||
+		value[DRAFT_STATE]
+	) {
+		return false
+	}
+	return (state as ProxyArrayState).baseRefs_!.has(value)
 }
 
 function readPropFromProto(state: ImmerState, source: any, prop: PropertyKey) {

--- a/src/plugins/arrayMethods.ts
+++ b/src/plugins/arrayMethods.ts
@@ -181,6 +181,7 @@ export function enableArrayMethods() {
 
 	function markAllIndicesReassigned(state: ProxyArrayState) {
 		state.allIndicesReassigned_ = true
+		state.baseRefs_ = new Set(state.base_)
 	}
 
 	function normalizeSliceIndex(index: number, length: number): number {


### PR DESCRIPTION
## Problem

immer's core contract is that the base state passed to `produce` is never mutated (the docs state the result is produced "without modifying the original `baseState`"). With `enableArrayMethods()`, calling `reverse()` or `sort()` inside a recipe and then mutating an element breaks this guarantee: the write lands on the user's base object.

### Repro

```js
import {produce, isDraft, enableArrayMethods, setAutoFreeze} from "immer"

enableArrayMethods()
setAutoFreeze(false)

const obj3 = {id: 3}
const base = [{id: 1}, {id: 2}, obj3]

const next = produce(base, d => {
  d.reverse()
  // isDraft(d[0]) === false  (bug: should be true)
  d[0].id = 99
})

// base is now [{id:1},{id:2},{id:99}]  and obj3 is {id:99}  -- base mutated
```

Without the plugin, vanilla immer handles the same recipe correctly.

## Root cause

`handleReorderingOperation` in `src/plugins/arrayMethods.ts` runs the native `reverse`/`sort` directly on `state.copy_`. Since `prepareCopy` shallow-copies `base_`, `copy_` still holds the raw base references, and the reorder relocates an un-drafted base object to a new index.

The get trap in `src/core/proxy.ts` only drafts a child when it sits at its original position (`value === peek(state.base_, prop)`). After a reorder `copy_[0] !== base_[0]`, so the check falls through and `return value` hands back the raw base object. Mutating it then mutates the base, and the generated patches/inverse are wrong too.

## Fix

Recognize a relocated base reference in the get trap and draft it before exposing it. The extra check only runs after a reorder (`allIndicesReassigned_`), skips indices the user explicitly assigned, and skips values that are already drafts or non-draftable, so the plugin's lazy-proxy optimization is preserved for the common path.

## Tests

Added two cases under "mutating array methods" in `__tests__/base.js`:

- `reverse()` then mutate index 0: asserts `isDraft(d[0])` is true, base and the relocated object are untouched, and the result is correct.
- `sort()` then mutate index 0 with `produceWithPatches`: same base-untouched assertions plus a patch / inverse-patch round-trip.

Both fail on `main` (in the array-plugin suite) and pass with the fix. Full suite is green (3669 passed, 8 skipped).
