### PR TITLE
fix: undefined assigned to a prototype-inherited key gets dropped

### DIFF
--- a/__tests__/regressions.js
+++ b/__tests__/regressions.js
@@ -5,10 +5,12 @@ import {
 	original,
 	isDraft,
 	immerable,
-	enableMapSet
+	enableMapSet,
+	enablePatches
 } from "../src/immer"
 
 enableMapSet()
+enablePatches()
 
 runBaseTest("proxy (no freeze)", true, false)
 runBaseTest("proxy (autofreeze)", true, true)
@@ -250,6 +252,26 @@ function runBaseTest(name, useProxies, autoFreeze, useListener) {
 			expect(newState).toEqual({
 				baz: undefined
 			})
+		})
+
+		test("#1160 assigning undefined to a key only present on the prototype is still stored as an own property", () => {
+			const proto = {[immerable]: true, name: undefined}
+			const state = Object.create(proto)
+
+			expect(Object.hasOwnProperty.call(state, "name")).toBe(false)
+
+			const [newState, patches] = produceWithPatches(state, draft => {
+				draft.name = undefined
+			})
+
+			expect(Object.hasOwnProperty.call(newState, "name")).toBe(true)
+			expect(patches).toEqual([
+				{
+					op: "add",
+					path: ["name"],
+					value: undefined
+				}
+			])
 		})
 
 		test("Nested and chained produce calls throw 'Cannot perform 'get' on a proxy that has been revoked' error", () => {

--- a/src/core/proxy.ts
+++ b/src/core/proxy.ts
@@ -241,7 +241,7 @@ export const objectTraps: ProxyHandler<ProxyState> = {
 		if (
 			(state.copy_![prop] === value &&
 				// special case: handle new props with value 'undefined'
-				(value !== undefined || prop in state.copy_)) ||
+				(value !== undefined || has(state.copy_, prop, state.type_))) ||
 			// special case: NaN
 			(Number.isNaN(value) && Number.isNaN(state.copy_![prop]))
 		)


### PR DESCRIPTION
Ran into this via #1160. If a draft's prototype has a key sitting at `undefined` (a class field with no initializer, or anything made with `Object.create`), assigning `undefined` to that same key on the draft is silently swallowed — no own property shows up on the result and no patch gets generated.

The `set` trap uses `prop in state.copy_` to tell "already has this key" apart from "brand new key," but `in` walks the prototype chain, so an inherited key looks like it's already there even though it isn't an own property yet. Swapped it for the `has()` own-property check that's already used a few lines above for basically the same reason.

Added a test in regressions.js that checks both `hasOwnProperty` on the result and the patch that comes out of `produceWithPatches`.