### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite dependency audit workflow to immer's CI pipeline. CVE Lite CLI is an OWASP Lab Project that scans yarn.lock (and other lockfiles) directly against the OSV advisory database without installing packages, making it fast and safe to run in CI.

A scan of immer's current lockfile found 56 total findings across 1,310 resolved packages, including critical and high severity vulnerabilities. The workflow runs on every push and pull request to main, plus a scheduled weekly scan on Monday mornings to catch new advisories even when the lockfile hasn't changed.

The workflow uses `fail-on: high` so any new high or critical severity finding in a PR will block the merge. SARIF output is enabled and uploaded to GitHub Code Scanning, which surfaces findings directly in the Security tab as code scanning alerts - no separate dashboard needed.

All GitHub Actions are pinned to immutable commit SHA digests rather than mutable version tags, which prevents supply chain attacks where a tag is moved to point at malicious code.

More details on CVE Lite CLI, including documentation and the full feature set, are at https://owasp.org/cve-lite-cli.
