### PR TITLE
docs: fix RFC-6902 JSON Pointer path conversion

### DIFF
--- a/website/docs/patches.mdx
+++ b/website/docs/patches.mdx
@@ -118,7 +118,7 @@ expect(state).toEqual({
 })
 ```
 
-The generated patches are similar (but not the same) to the [RFC-6902 JSON patch standard](https://datatracker.ietf.org/doc/html/rfc6902/#section-4.1), except that the `path` property is an array, rather than a string. This makes processing patches easier. If you want to normalize to the official specification, `patch.path = patch.path.join("/")` should do the trick. Anyway, this is what a bunch of patches and their inverse could look like:
+The generated patches are similar (but not the same) to the [RFC-6902 JSON patch standard](https://datatracker.ietf.org/doc/html/rfc6902/#section-4.1), except that the `path` property is an array, rather than a string. This makes processing patches easier. If you want to normalize to the official specification, use `patch.path = "/" + patch.path.join("/")` so the result is a JSON Pointer with a leading `/` (and escape `~` / `/` in path tokens per [RFC-6901](https://datatracker.ietf.org/doc/html/rfc6901) when needed). Anyway, this is what a bunch of patches and their inverse could look like:
 
 ```json
 [

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/patches.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/patches.mdx
@@ -119,7 +119,7 @@ expect(state).toEqual({
 })
 ```
 
-生成的 patches 与 [RFC-6902 JSON patch standard](https://datatracker.ietf.org/doc/html/rfc6902/#section-4.1) 类似（但并不相同），除了 path 属性是一个数组，而不是一个字符串。这使得处理 patches 更加容易。如果你想规范化到官方格式，`patch.path = patch.path.join("/")`应该可以解决这个问题。无论如何，下面就是一堆 patches 和它们回溯的样子。
+生成的 patches 与 [RFC-6902 JSON patch standard](https://datatracker.ietf.org/doc/html/rfc6902/#section-4.1) 类似（但并不相同），除了 path 属性是一个数组，而不是一个字符串。这使得处理 patches 更加容易。如果你想规范化到官方格式，请使用 `patch.path = "/" + patch.path.join("/")`，这样会得到带前导 `/` 的 JSON Pointer（如有需要，请按 [RFC-6901](https://datatracker.ietf.org/doc/html/rfc6901) 转义路径段中的 `~` / `/`）。无论如何，下面就是一堆 patches 和它们回溯的样子。
 
 ```json
 [


### PR DESCRIPTION
## Summary
- Corrects the patches docs tip for converting Immer path arrays into RFC-6902 JSON Pointers.
- Uses a leading `/` (`"/" + patch.path.join("/")`) so the result matches RFC-6901 JSON Pointers.
- Notes token escaping for `~` and `/`, and updates the zh-CN translation to match.

Fixes #1051

## Test plan
- [ ] Confirm the English and zh-CN patches pages render the updated sentence
- [ ] Confirm `"/" + ["a","b"].join("/")` yields `/a/b` as described in the issue