### PR TITLE
docs: show todo.done in useImmer checkbox example

### DIFF
--- a/website/docs/example-setstate.mdx
+++ b/website/docs/example-setstate.mdx
@@ -117,10 +117,27 @@ const TodoList = () => {
     });
   }, []);
 
-  // etc
+  return (
+    <ul>
+      {todos.map((todo) => (
+        <li key={todo.id}>
+          <label>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => handleToggle(todo.id)}
+            />
+            {todo.title}
+          </label>
+        </li>
+      ))}
+      <button type="button" onClick={handleAdd}>
+        Add todo
+      </button>
+    </ul>
+  );
+};
 ```
-
-For the full demo see [CodeSandbox](https://codesandbox.io/s/use-immer-bvd5v?file=/src/index.js).
 
 ## useReducer + Immer
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/example-setstate.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/example-setstate.mdx
@@ -117,10 +117,27 @@ const TodoList = () => {
     });
   }, []);
 
-  // etc
+  return (
+    <ul>
+      {todos.map((todo) => (
+        <li key={todo.id}>
+          <label>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => handleToggle(todo.id)}
+            />
+            {todo.title}
+          </label>
+        </li>
+      ))}
+      <button type="button" onClick={handleAdd}>
+        Add todo
+      </button>
+    </ul>
+  );
+};
 ```
-
-完整的 demo 请参阅 [CodeSandbox](https://codesandbox.io/s/use-immer-bvd5v?file=/src/index.js)
 
 ## useReducer + Immer
 


### PR DESCRIPTION
## Summary
- Fixes #1011 by completing the `useImmer` todo list example with the correct `checked={todo.done}` binding
- Removes the broken CodeSandbox link that used `todo.finished` while state objects use `done`
- Updates both English and zh-CN docs pages

## Test plan
- [x] Verified the example uses `todo.done` consistently for state updates and checkbox `checked`
- [x] Confirmed no other doc references to the outdated CodeSandbox remain on this page