### PR TITLE
fix: remove global var Iterator declaration conflicting with ESNext lib (#1273)

### DIFF
--- a/src/plugins/mapset.ts
+++ b/src/plugins/mapset.ts
@@ -20,14 +20,16 @@ import {
 	handleCrossReference
 } from "../internal"
 
-declare global {
-	// `Iterator.from` was added in ES2025.
-	var Iterator:
-		| undefined
-		| {
-				from<T, TReturn>(iterable: Iterator<T, TReturn>): IterableIterator<T>
-		  }
-}
+// Feature-detect `Iterator.from` (added in ES2025) without augmenting the
+// global scope. Declaring `var Iterator` in a `declare global` block leaks a
+// conflicting global variable into the bundled `.d.ts` (TS2403 when compiled
+// against the ESNext lib). We cast via `globalThis` to satisfy the type checker
+// while keeping the runtime feature detect accurate. (#1273)
+const _globalIterator = (globalThis as any).Iterator as
+	| undefined
+	| { from: <T>(iterable: Iterator<T>) => IterableIterator<T> }
+const hasIteratorFrom =
+	typeof _globalIterator?.from === "function"
 
 export function enableMapSet() {
 	class DraftMap extends Map {
@@ -173,8 +175,8 @@ export function enableMapSet() {
 	function iteratorFrom<T, TReturn>(
 		iterable: Iterator<T, TReturn>
 	): IterableIterator<T> {
-		if (typeof Iterator !== "undefined") {
-			return Iterator.from(iterable)
+		if (hasIteratorFrom) {
+			return _globalIterator!.from(iterable)
 		}
 
 		const iterator: IterableIterator<T> = {


### PR DESCRIPTION
## Summary

The `declare global { var Iterator }` shim added to feature-detect ES2025's `Iterator.from` leaks a global variable declaration into the bundled `dist/immer.d.ts`. Consumers compiling against the `esnext` lib hit TS2403 because the global `Iterator` now collides with the standard `IteratorConstructor`.

## Changes (packages/immer/src/plugins/mapset.ts)

- Removed the `declare global { var Iterator }` block.
- Added a module-scoped feature detect that reads the iterator constructor off `globalThis` (`_globalIterator`), so the emitted `.d.ts` no longer declares a conflicting global.
- `iteratorFrom` uses `_globalIterator!.from` when present, otherwise the existing manual fallback.

Runtime behavior is unchanged.

## Test

- `bun run build` succeeds; `dist/immer.d.ts` no longer contains a global `var Iterator`.
- Repro with `--lib esnext --noEmit` against `dist/immer`: no TS2403.
- `bun run test:src`: 3755 passed, 8 skipped.

Fixes #1273
